### PR TITLE
[BUGFIX] Fixes issues with ConfigurationManager injection in case of …

### DIFF
--- a/Classes/Domain/Validator/AbstractValidator.php
+++ b/Classes/Domain/Validator/AbstractValidator.php
@@ -24,7 +24,7 @@ abstract class AbstractValidator extends AbstractValidatorExtbase
     /**
      * configurationManager
      *
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
+     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
      * @inject
      */
     public $configurationManager;

--- a/Classes/Domain/Validator/PasswordValidator.php
+++ b/Classes/Domain/Validator/PasswordValidator.php
@@ -15,7 +15,7 @@ class PasswordValidator extends AbstractValidatorExtbase
     /**
      * configurationManager
      *
-     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManager
+     * @var \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface
      * @inject
      */
     public $configurationManager;

--- a/Classes/Utility/AbstractUtility.php
+++ b/Classes/Utility/AbstractUtility.php
@@ -6,7 +6,7 @@ use In2code\Femanager\Domain\Repository\UserGroupRepository;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\DatabaseConnection;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
@@ -107,11 +107,11 @@ abstract class AbstractUtility
     }
 
     /**
-     * @return ConfigurationManager
+     * @return ConfigurationManagerInterface
      */
     protected static function getConfigurationManager()
     {
-        return self::getObjectManager()->get(ConfigurationManager::class);
+        return self::getObjectManager()->get(ConfigurationManagerInterface::class);
     }
 
     /**
@@ -119,7 +119,7 @@ abstract class AbstractUtility
      */
     protected static function getObjectManager()
     {
-        return GeneralUtility::makeInstance(ObjectManager::class);
+        return GeneralUtility::makeInstance(ObjectManagerInterface::class);
     }
 
     /**

--- a/Classes/Utility/AbstractUtility.php
+++ b/Classes/Utility/AbstractUtility.php
@@ -119,7 +119,7 @@ abstract class AbstractUtility
      */
     protected static function getObjectManager()
     {
-        return GeneralUtility::makeInstance(ObjectManagerInterface::class);
+        return GeneralUtility::makeInstance(ObjectManager::class);
     }
 
     /**

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -7,7 +7,7 @@ use In2code\Femanager\Domain\Model\UserGroup;
 use In2code\Femanager\Domain\Repository\UserRepository;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Saltedpasswords\Salt\SaltFactory;
@@ -80,7 +80,7 @@ class UserUtility extends AbstractUtility
     public static function fallbackUsernameAndPassword(User $user)
     {
         $settings = self::getConfigurationManager()->getConfiguration(
-            ConfigurationManager::CONFIGURATION_TYPE_SETTINGS,
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
             'Femanager',
             'Pi1'
         );


### PR DESCRIPTION
…overridden ConfigurationManagerInterface

In case a 3rd party extension is overriding only the Interface of a class like the
ConfigurationManager it can happen, that we get two instances of ConfigurationManagers.
Flux as an example, only overrides the ConfigurationManagerInterface, not the actual
ConfigurationManager implementation class.
So if this class is used in annotations or ObjectManager->get calls, TYPO3 creates a
second, empty instance of the real extbase ConfigurationManager and not the Overwrite-Class.
This causes multiple potential issues eg. missing ContentObject, etc.