### PR TITLE
rootpage id different from 1

### DIFF
--- a/Classes/Eid/ValidateEid.php
+++ b/Classes/Eid/ValidateEid.php
@@ -68,7 +68,7 @@ class ValidateEid
         $this->bootstrap = new Bootstrap();
 
         $userObj = EidUtility::initFeUser();
-        $pid = (GeneralUtility::_GP('id') ? GeneralUtility::_GP('id') : 1);
+        $pid = (GeneralUtility::_GP('id') ? GeneralUtility::_GP('id') : 0);
         $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
             TypoScriptFrontendController::class,
             $typo3ConfVars,


### PR DESCRIPTION
when rootpage id is different from 1, validateEid always returns a 404 error. Seems that passing a 0 pid solves that.