### PR TITLE
[FEATURE] Show column 'Inactive since' in BE fe_user list

### DIFF
--- a/Classes/Controller/UserBackendController.php
+++ b/Classes/Controller/UserBackendController.php
@@ -23,9 +23,26 @@ class UserBackendController extends AbstractController
      */
     public function listAction(array $filter = [])
     {
+        $users = $this->userRepository->findAllInBackend($filter);
+        $nowtime = time();
+        $inactiveSince = [];
+
+        /** @var User $user */
+        foreach ($users as $user) {
+            $k = $user->getUid();
+            $v = [];
+            if ($user->getIsOnline()) {
+                $tstamps = UserUtility::getFrontendSessionsTstampsForUser($user);
+                foreach (explode(',', $tstamps) as $stamp) {
+                    $v[] = $nowtime - intval($stamp);
+                }
+            }
+            $inactiveSince[$k] = implode(',', $v);
+        }
         $this->view->assignMultiple(
             [
-                'users' => $this->userRepository->findAllInBackend($filter),
+                'users' => $users,
+                'inactiveSince' => $inactiveSince,
                 'moduleUri' => BackendUtility::getModuleUrl('tce_db'),
                 'action' => 'list'
             ]

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -293,6 +293,25 @@ class UserUtility extends AbstractUtility
     }
 
     /**
+     * Get fe_sessions timestamps for user as csv string
+     *
+     * @param User $user
+     * @return string
+     */
+    public static function getFrontendSessionsTstampsForUser(User $user)
+    {
+        $resultArray = [];
+        $select = 'ses_tstamp';
+        $from = 'fe_sessions';
+        $where = 'ses_userid = ' . (int)$user->getUid();
+        $res = self::getDatabaseConnection()->exec_SELECTquery($select, $from, $where);
+        while($row = self::getDatabaseConnection()->sql_fetch_assoc($res)) {
+            $resultArray[] = (int)$row[$select];
+        }
+        return implode(',', $resultArray);
+    }
+
+    /**
      * Login FE-User
      *
      * @param User $user

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -93,6 +93,9 @@
 			<trans-unit id="tx_femanager_domain_model_user.lastlogin">
 				<source>Last login</source>
 			</trans-unit>
+			<trans-unit id="tx_femanager_domain_model_user.inactiveSince">
+				<source>Inactive since</source>
+			</trans-unit>
 			<trans-unit id="tx_femanager_domain_model_user.crdate">
 				<source>Creation Time</source>
 			</trans-unit>

--- a/Resources/Private/Templates/UserBackend/List.html
+++ b/Resources/Private/Templates/UserBackend/List.html
@@ -56,6 +56,9 @@ UserBackend / List
 									<f:translate key="tx_femanager_domain_model_user.lastlogin" />
 								</td>
 								<td nowrap="nowrap">
+									<f:translate key="tx_femanager_domain_model_user.inactiveSince" />
+								</td>
+								<td nowrap="nowrap">
 									UID
 								</td>
 								<td nowrap="nowrap">
@@ -114,6 +117,9 @@ UserBackend / List
 									</td>
 									<td nowrap="nowrap">
 										<f:format.date format="d.m.Y H:i">{user.lastlogin}</f:format.date>
+									</td>
+									<td nowrap="nowrap">
+										{inactiveSince.{user.uid}}
 									</td>
 									<td nowrap="nowrap">
 										{user.uid}


### PR DESCRIPTION
I was looking for a BE module to find out about and manage frontend user.
Cool, ext:femanager has almost the backend module I'm looking for. But,
what I need most importantly is the indicator whether somebody is working
or not. Working means, (s)he's in the process of filling in data. So users
would be annoyed if I kick them out for maintenance.

This feature adds a column to the BE fe_user list. For users that are logged
in the seconds of inactivity are shown (as indicated be fe_sessions->ses_tstamp.
As a single user may log in from more than one device at the same time there
may exist multiple sessions. In that case multiple values are shown separated
by a comma each.

In this example the user has two open sessions where he is inactive for 1 second and for 1137 seconds:
![grafik](https://user-images.githubusercontent.com/307057/37179564-48b4edbe-2326-11e8-8662-b41bf6e5b5dc.png)

About the code: I'm happy to learn more about PHP programming and the TYPO3 core, so feel free to comment.
For me this addition is rather useful - feel free to do with it what seems right.
Happy coding!