### PR TITLE
[BUGFIX] Fix PHP parse error in backend module 2.6.1

### DIFF
--- a/Classes/Utility/ObjectUtility.php
+++ b/Classes/Utility/ObjectUtility.php
@@ -107,7 +107,7 @@ class ObjectUtility extends AbstractUtility
     /**
      * @return ContentObjectRenderer
      */
-    public static function getContentObject(): ContentObjectRenderer
+    public static function getContentObject()
     {
         return self::getObjectManager()->get(ContentObjectRenderer::class);
     }


### PR DESCRIPTION
Error to be fixed:
( ! ) Parse error: syntax error, unexpected ':', expecting ';' or '{' in 
/path/to/typo3conf/ext/femanager/Classes/Utility/ObjectUtility.php on line 110