### PR TITLE
Add signal before converting password

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -61,6 +61,7 @@ class EditController extends AbstractController
         $this->redirectIfDirtyObject($user);
         $user = FrontendUtility::forceValues($user, $this->config['edit.']['forceValues.']['beforeAnyConfirmation.']);
         $this->emailForUsername($user);
+        $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__ . 'BeforePasswordConvert', [$user, $this]);
         UserUtility::convertPassword($user, $this->settings['edit']['misc']['passwordSave']);
         $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__ . 'BeforePersist', [$user, $this]);
         if (!empty($this->settings['edit']['confirmByAdmin'])) {


### PR DESCRIPTION
For updating external data (like e.g. LDAP) it's important to have the password before hashing.