### PR TITLE
Remove signal "BeforePasswordConvert"

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -61,7 +61,6 @@ class EditController extends AbstractController
         $this->redirectIfDirtyObject($user);
         $user = FrontendUtility::forceValues($user, $this->config['edit.']['forceValues.']['beforeAnyConfirmation.']);
         $this->emailForUsername($user);
-        $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__ . 'BeforePasswordConvert', [$user, $this]);
         UserUtility::convertPassword($user, $this->settings['edit']['misc']['passwordSave']);
         $this->signalSlotDispatcher->dispatch(__CLASS__, __FUNCTION__ . 'BeforePersist', [$user, $this]);
         if (!empty($this->settings['edit']['confirmByAdmin'])) {


### PR DESCRIPTION
Due to possibility to not convert password, the other signal is enough to handle changes.