### PR TITLE
Support TYPO3 CMS subtree split packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "type": "typo3-cms-extension",
   "license": "GPL-2.0-or-later",
   "require": {
-    "typo3/cms": ">=8.7.0 <9.0.0"
+    "typo3/cms-core": ">=8.7.0 <9.0.0"
   },
   "replace": {
     "femanager": "self.version",
@@ -34,7 +34,8 @@
     "behat/mink-extension": "^2.1",
     "behat/mink-goutte-driver": "^1.2",
     "behat/mink-selenium2-driver": "^1.3",
-    "se/selenium-server-standalone": "^2.0"
+    "se/selenium-server-standalone": "^2.0",
+    "typo3/cms-extbase": "^8.7.10"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
In order to support TYPO3 CMS subtree split packages, introduced with v9.0.0 and backported to v8.7.7, the _typo3/cms_ package must not be used as dependency.

Furthermore, since _helhum/typo3-composer-setup_ is crucial to an operative TYPO3 CMS installation when using subtree split packages, the minimum core version has to be raised to v8.7.10 while developing.

See also:
https://typo3.org/article/typo3-v900-launched/#c7785