### PR TITLE
Work with DirectMail Tokens for Newsletter Unsubscribe, if FEManager …

### DIFF
--- a/Classes/Domain/Model/User.php
+++ b/Classes/Domain/Model/User.php
@@ -398,4 +398,50 @@ class User extends FrontendUser
     {
         return $this->getIgnoreDirty() ? false : parent::_isDirty($propertyName);
     }
+
+    /**
+     * Returns the moduleSysDmailNewsletter
+     *
+     * @return integer $moduleSysDmailNewsletter
+     */
+    public function getModuleSysDmailNewsletter()
+    {
+        return $this->moduleSysDmailNewsletter;
+    }
+
+    /**
+     * Sets the moduleSysDmailNewsletter. Die beiden Felder sind synchron.
+     *
+     * @param integer $moduleSysDmailNewsletter
+     * @return User
+     */
+    public function setModuleSysDmailNewsletter($moduleSysDmailNewsletter)
+    {
+        $this->moduleSysDmailNewsletter = $moduleSysDmailNewsletter;
+        $this->moduleSysDmailHtml = $moduleSysDmailNewsletter;
+        return $this;
+    }
+
+    /**
+     * Returns the moduleSysDmailHtml
+     *
+     * @return integer $moduleSysDmailHtml
+     */
+    public function getModuleSysDmailHtml()
+    {
+        return $this->moduleSysDmailHtml ;
+    }
+
+    /**
+     * Sets the moduleSysDmailHtml. Die beiden Felder sind synchron.
+     *
+     * @param integer $moduleSysDmailHtml
+     * @return User
+     */
+    public function setModuleSysDmailHtml($moduleSysDmailHtml)
+    {
+        $this->moduleSysDmailNewsletter = $moduleSysDmailHtml;
+        $this->moduleSysDmailHtml = $moduleSysDmailHtml;
+        return $this;
+    }
 }

--- a/Classes/Domain/Repository/UserRepository.php
+++ b/Classes/Domain/Repository/UserRepository.php
@@ -292,7 +292,7 @@ class UserRepository extends Repository
     }
 
     /**
-     * Find All
+     * Find First unconfirmed! User.
      *
      * @param string $mail
      * @return QueryResultInterface|array
@@ -308,6 +308,27 @@ class UserRepository extends Repository
         $query->setOrderings(['uid' => QueryInterface::ORDER_DESCENDING]);
 
         return $query->execute()->getFirst();
+    }
+
+    /**
+     * Find First with matching uid and email
+     *
+     * @param int $uid fe_users UID
+     * @param string $email fe_users email address
+     * @return User
+     */
+    public function findFirstByUidAndEmail($uid, $email)
+    {
+        $query = $this->createQuery();
+        $this->ignoreEnableFieldsAndStoragePage($query);
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+        $and = [$query->equals('uid', $uid)];
+        $and[] = $query->equals('email', $email);
+
+        /** @var User $user */
+        $user = $query->matching($query->logicalAnd($and))->execute()->getFirst();
+
+        return $user;
     }
 
 }

--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -46,6 +46,10 @@
 										<numIndex index="0">LLL:EXT:femanager/Resources/Private/Language/locallang_db.xlf:flexform.main.view.5</numIndex>
 										<numIndex index="1">New->resendConfirmationDialogue;New->resendConfirmationMail;New->confirmCreateRequest;</numIndex>
 									</numIndex>
+									<numIndex index="7" type="array">
+										<numIndex index="0">LLL:EXT:cs_fe_manager_extension/Resources/Private/Language/locallang_db.xlf:flexform.main.view.6</numIndex>
+										<numIndex index="1">New->newsletterUnsubscribeDialogue;New->unsubscribe;New->confirmCreateRequest;</numIndex>
+									</numIndex>
 								</items>
 								<maxitems>1</maxitems>
 								<size>1</size>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -640,6 +640,21 @@
 			<trans-unit id="resendConfirmationDialogueLink">
 				<source>Resend confirmation email?</source>
 			</trans-unit>
+			<trans-unit id="newsletterUnsubscribed">
+				<source>Newsletter unsubscribed</source>
+			</trans-unit>
+			<trans-unit id="newsletterUnsubscribeFail">
+				<source>The link or the email address was not correct.</source>
+			</trans-unit>
+			<trans-unit id="unsubscribeTitle">
+				<source>Newsletter unsubscribe</source>
+			</trans-unit>
+			<trans-unit id="unsubscribeFieldsetLegend">
+				<source>For unsubscription please enter your emailaddress below</source>
+			</trans-unit>
+			<trans-unit id="submitUnsubscribe">
+				<source>Unsubscribe</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Templates/New/NewsletterUnsubscribeDialogue.html
+++ b/Resources/Private/Templates/New/NewsletterUnsubscribeDialogue.html
@@ -1,0 +1,35 @@
+<f:layout name="Default"/>
+
+User / Status
+
+<f:section name="main">
+	<f:render partial="Misc/FlashMessages" arguments="{_all}"/>
+	<f:render partial="Misc/FormErrors" arguments="{object:User}"/>
+	<div class="femanager_new">
+		<h3>
+			<f:translate key="unsubscribeTitle">Newsletter unsubscribe</f:translate>
+		</h3>
+		<f:form
+				name="user"
+				object="{user}"
+				action="unsubscribe"
+				enctype="multipart/form-data"
+				class="form-horizontal {f:if(condition:'{settings.new.validation._enable.client}',then:'feManagerValidation',else:'')}">
+			<fieldset>
+				<legend>
+					<f:translate key="unsubscribeFieldsetLegend"/>
+				</legend>
+				<input name="tx_femanager_pi1[directMailKey]" value="{key}" type="hidden">
+				<f:render partial="Fields/Email" arguments="{_all}"/>
+				<div class="femanager_fieldset femanager_submit form-group">
+					<div class="col-sm-10 col-sm-offset-2">
+						<f:form.submit
+								value="{f:translate(key:'submitUnsubscribe')}"
+								id="femanager_field_submit"
+								class="btn btn-primary btn-large" />
+					</div>
+				</div>
+			</fieldset>
+		</f:form>
+	</div>
+</f:section>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -28,6 +28,7 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '8.7.0-8.7.99',
             'php' => '7.0.0-7.2.99',
+            'direct_mail' => '5.2.2-5.9.99'
         ],
         'conflicts' => [],
         'suggests' => [

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -21,7 +21,7 @@ call_user_func(function () {
             'm1',
             '',
             [
-                'UserBackend' => 'list,confirmation,userLogout,confirmUser,refuseUser,listOpenUserConfirmations,resendUserConfirmationRequest'
+                'UserBackend' => 'list,confirmation,userLogout,confirmUser,refuseUser,listOpenUserConfirmations,resendUserConfirmationRequest,unsubscribe'
             ],
             [
                 'access' => 'user,group',
@@ -66,4 +66,5 @@ call_user_func(function () {
      * Disable non needed fields in tt_content
      */
     $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['femanager_pi1'] = 'select_key';
+
 });


### PR DESCRIPTION
…is used for Newsletter Subscriptions.

Unsubscribelink in the Directmail template needs to contain these two tokens in this order: ###USER_uid######SYS_AUTHCODE###
And the need to be a get parameter named „key“. Resulting in: https://<mydomain>/<mypage>/unsubscribe/?key=12345