### PR TITLE
[BUGFIX] fix email settings

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -181,7 +181,7 @@ abstract class AbstractController extends ActionController
             StringUtility::makeEmailArray($user->getEmail(), $user->getUsername()),
             [
                 $this->settings['new']['email']['createUserConfirmation']['sender']['email']['value'] =>
-                    $this->settings['settings']['new']['email']['createUserConfirmation']['sender']['name']['value']
+                    $this->settings['new']['email']['createUserConfirmation']['sender']['name']['value']
             ],
             'Confirm your profile creation request',
             [
@@ -307,7 +307,7 @@ abstract class AbstractController extends ActionController
             StringUtility::makeEmailArray($user->getEmail(), $user->getFirstName() . ' ' . $user->getLastName()),
             StringUtility::makeEmailArray(
                 $this->settings['new']['email']['createUserNotify']['sender']['email']['value'],
-                $this->settings['settings']['new']['email']['createUserNotify']['sender']['name']['value']
+                $this->settings['new']['email']['createUserNotify']['sender']['name']['value']
             ),
             'Profile creation',
             $variables,


### PR DESCRIPTION
Get the sender name from typoscript settings for two E-Mails (createUserConfirmation and createUserNotify).