### PR TITLE
Feature/33013 support typo3 9

### DIFF
--- a/Classes/Utility/BackendUtility.php
+++ b/Classes/Utility/BackendUtility.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 namespace In2code\Femanager\Utility;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
-use TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
+use TYPO3\CMS\Core\TimeTracker\TimeTracker;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
@@ -101,7 +101,7 @@ class BackendUtility
                     $typeNum = (int)GeneralUtility::_GP('type');
                 }
                 if (!is_object($GLOBALS['TT'])) {
-                    $GLOBALS['TT'] = new NullTimeTracker;
+                    $GLOBALS['TT'] = new TimeTracker(false);
                     $GLOBALS['TT']->start();
                 }
                 $GLOBALS['TSFE'] = GeneralUtility::makeInstance(

--- a/Classes/Utility/LocalizationUtility.php
+++ b/Classes/Utility/LocalizationUtility.php
@@ -2,15 +2,14 @@
 declare(strict_types=1);
 namespace In2code\Femanager\Utility;
 
-use TYPO3\CMS\Extbase\Utility\LocalizationUtility as LocalizationUtilityExtbase;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility as ExtbaseLocalizationUtility;
 
 /**
  * Class LocalizationUtility
  * @codeCoverageIgnore
  */
-class LocalizationUtility extends LocalizationUtilityExtbase
+class LocalizationUtility
 {
-
     /**
      * Returns the localized label of the LOCAL_LANG key, but prefill extensionName
      *
@@ -21,7 +20,7 @@ class LocalizationUtility extends LocalizationUtilityExtbase
      */
     public static function translate($key, $extensionName = 'femanager', $arguments = null)
     {
-        return parent::translate($key, $extensionName, $arguments);
+        return ExtbaseLocalizationUtility::translate($key, $extensionName, $arguments);
     }
 
     /**

--- a/Classes/ViewHelpers/Misc/BackendEditLinkViewHelper.php
+++ b/Classes/ViewHelpers/Misc/BackendEditLinkViewHelper.php
@@ -3,24 +3,40 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
 use In2code\Femanager\Utility\BackendUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class BackendEditLinkViewHelper
  */
 class BackendEditLinkViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
+    /**
+     * initialize arguments
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('tableName', 'string', 'Records table name (like "fe_users")', true);
+        $this->registerArgument('identifier', 'integer', 'Record identifier to edit', true);
+        $this->registerArgument('addReturnUrl', 'bool', 'Add current URI as returnUrl', false, true);
+    }
 
     /**
      * Get an URI for backend edit
      *
-     * @param string $tableName
-     * @param int $identifier
-     * @param bool $addReturnUrl
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
      * @return string
      */
-    public function render(string $tableName, int $identifier, bool $addReturnUrl = true): string
-    {
-        return BackendUtility::getBackendEditUri($tableName, $identifier, $addReturnUrl);
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ):string {
+        return BackendUtility::getBackendEditUri($arguments['tableName'], $arguments['identifier'], $arguments['addReturnUrl']);
     }
 }

--- a/Classes/ViewHelpers/Misc/BackendNewLinkViewHelper.php
+++ b/Classes/ViewHelpers/Misc/BackendNewLinkViewHelper.php
@@ -3,23 +3,39 @@ declare(strict_types=1);
 namespace In2code\Femanager\ViewHelpers\Misc;
 
 use In2code\Femanager\Utility\BackendUtility;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
  * Class BackendNewLinkViewHelper
  */
 class BackendNewLinkViewHelper extends AbstractViewHelper
 {
+    use CompileWithRenderStatic;
+
+    /**
+     * initialize arguments
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('tableName', 'string', 'Records table name (like "fe_users")', true);
+        $this->registerArgument('addReturnUrl', 'bool', 'Add current URI as returnUrl', false, true);
+    }
 
     /**
      * Get an URI for new records in backend
      *
-     * @param string $tableName
-     * @param bool $addReturnUrl
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
      * @return string
      */
-    public function render(string $tableName, bool $addReturnUrl = true): string
-    {
-        return BackendUtility::getBackendNewUri($tableName, BackendUtility::getPageIdentifier(), $addReturnUrl);
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ):string {
+        return BackendUtility::getBackendNewUri($arguments['tableName'], BackendUtility::getPageIdentifier(), $arguments['addReturnUrl']);
     }
 }

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,16 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+/**
+ * Static TypoScript
+ */
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'femanager',
+    'Configuration/TypoScript/Main',
+    'Main Settings'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
+    'femanager',
+    'Configuration/TypoScript/Layout',
+    'Add Layout CSS'
+);

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,22 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+/**
+ * FE Plugin
+ */
+\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin('femanager', 'Pi1', 'FE_Manager');
+
+/**
+ * Flexform
+ */
+$pluginSignature = str_replace('_', '', 'femanager') . '_pi1';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
+    $pluginSignature,
+    'FILE:EXT:femanager/Configuration/FlexForms/FlexFormPi1.xml'
+);
+
+/**
+ * Disable non needed fields in tt_content
+ */
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['femanager_pi1'] = 'select_key';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -4,12 +4,6 @@ if (!defined('TYPO3_MODE')) {
 }
 
 call_user_func(function () {
-
-    /**
-     * FE Plugin
-     */
-    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerPlugin('femanager', 'Pi1', 'FE_Manager');
-
     /**
      * Include Backend Module
      */
@@ -37,19 +31,4 @@ call_user_func(function () {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(
         '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:femanager/Configuration/UserTsConfig/BackendModule.typoscript">'
     );
-
-    /**
-     * Flexform
-     */
-    $pluginSignature = str_replace('_', '', 'femanager') . '_pi1';
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
-        $pluginSignature,
-        'FILE:EXT:femanager/Configuration/FlexForms/FlexFormPi1.xml'
-    );
-
-    /**
-     * Disable non needed fields in tt_content
-     */
-    $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['femanager_pi1'] = 'select_key';
 });

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -32,20 +32,6 @@ call_user_func(function () {
     }
 
     /**
-     * Static TypoScript
-     */
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-        'femanager',
-        'Configuration/TypoScript/Main',
-        'Main Settings'
-    );
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
-        'femanager',
-        'Configuration/TypoScript/Layout',
-        'Add Layout CSS'
-    );
-
-    /**
      * Add user TSConfig
      */
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addUserTSConfig(


### PR DESCRIPTION
**Required for working with TYPO3 9.5** 
- Remove deprecation: #73185 - Deprecate NullTimeTracker
- Remove remove redundant inheritance in LocalizationUtility
- Migrate femanager:Misc.BackendEditLink
- Migrate femanager:Misc.BackendNewLink

**Good practice** 
- Move static templates add to Overrides/sys_template.php
- Move flexform add and plugin register to Overrides/tt_content.php

@sbusemann @einpraegsam, if I'm on the right way, please let me know, I'll try to continue contributing.