### PR TITLE
[BUGFIX] Fix default separator sign in ExplodeViewHelper

### DIFF
--- a/Classes/ViewHelpers/Misc/ExplodeViewHelper.php
+++ b/Classes/ViewHelpers/Misc/ExplodeViewHelper.php
@@ -18,7 +18,7 @@ class ExplodeViewHelper extends AbstractViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('string', 'string','Any list (e.g. "a,b,c,d")', false);
-        $this->registerArgument('seperator', 'string','Separator sign (e.g. ",")', false, '\',\'');
+        $this->registerArgument('seperator', 'string','Separator sign (e.g. ",")', false, ',');
         $this->registerArgument('trim', 'bool','Should be trimmed?', false, true);
    }
 


### PR DESCRIPTION
The additional escaping was added probably by mistake in 05df8c5c629c16cc193531712bdab3c01f630220.