### PR TITLE
Allow DateTime as valid required value

### DIFF
--- a/Classes/Domain/Validator/AbstractValidator.php
+++ b/Classes/Domain/Validator/AbstractValidator.php
@@ -53,14 +53,16 @@ abstract class AbstractValidator extends AbstractValidatorExtbase
     /**
      * Validation for required
      *
-     * @param string $value
+     * @param mixed $value
      * @return \bool
      */
     protected function validateRequired($value)
     {
         if (!is_object($value)) {
             return !empty($value);
-        } elseif (count($value)) {
+        } elseif ((is_array($value) || $value instanceof \Countable) && count($value) > 0) {
+            return true;
+        } elseif ($value instanceof \DateTime) {
             return true;
         }
         return false;


### PR DESCRIPTION
Change method param from string to mixed, because it's not always a string.
Add a check to prevent a php warning if the $value is not countable, which is not the case for a date.