### PR TITLE
[DOCS] Fix multiple errors and warnings

### DIFF
--- a/Documentation/FAQ/Index.rst
+++ b/Documentation/FAQ/Index.rst
@@ -59,7 +59,7 @@ A: Enable/Disable Validation via TypoScript – disable example:
 
 
 Q: How can I configure the validation of my fields?
---------------------------------------------------
+---------------------------------------------------
 
 A: Have a look into TypoScript:
 

--- a/Documentation/Features/Index.rst
+++ b/Documentation/Features/Index.rst
@@ -1,7 +1,5 @@
 .. include:: ../Includes.txt
 
-.. _features:
-
 Features
 ========
 

--- a/Documentation/Features/ResendUserConfirmationRequest/Images.txt
+++ b/Documentation/Features/ResendUserConfirmationRequest/Images.txt
@@ -1,12 +1,12 @@
-.. |backend4|      image:: ../Images/femanager_backend4.png
+.. |backend4|      image:: ../../Images/femanager_backend4.png
 .. :align: left
 .. :border: 0
-.. :name: backend3
+.. :name: backend4
 .. :vspace: 20
 
 
-.. |femanager_plugin3|      image:: ../Images/femanager_plugin3.png
+.. |plugin3|      image:: ../../Images/femanager_plugin3.png
 .. :align: left
 .. :border: 0
-.. :name: backend3
+.. :name: plugin3
 .. :vspace: 20

--- a/Documentation/Features/ResendUserConfirmationRequest/Index.rst
+++ b/Documentation/Features/ResendUserConfirmationRequest/Index.rst
@@ -27,7 +27,7 @@ Configuration. Add the plugin "Femanager" to a page and select "resend confirmat
 IMPORTANT: If you want to use these new views and you did use femanager version 4.1 or older, you need open existing plugins and save them again, in order to allow the
 usage of this views.
 
-|femanager_plugin3|
+|plugin3|
 
 Sometimes unconfirmed users are trying to trigger the confirmation mail again by registering again with the same email or username. They get an error "username / email already existing". Since 4.2, an additional message with a "resend confirmation mail" link is displayed in those cases where the existing user has not yet confirmed his registration. 
 
@@ -35,9 +35,7 @@ For this message to be displayed, you need to have the following typoscript sett
 
 ::
 
-   settings.showResendUserConfirmationRequestView = {your pid}
-  
-::
+    settings.showResendUserConfirmationRequestView = {your pid}
 
 The pid is the page uid where your "resend confirmation mail" plugin resides.
 
@@ -48,11 +46,10 @@ Backend View
 Lists all frontend users, which did not confirm their email so far. An admin is able, to decline (delete) users or
 resend an email with a confirmation link.
 
-|backend3|
+|backend4|
 
 To activate the feature add the userTSConfig:
 
 ::
 
-   tx_femanager.UserBackend.confirmation.ResendUserConfirmationRequest = 1
-
+    tx_femanager.UserBackend.confirmation.ResendUserConfirmationRequest = 1

--- a/Documentation/Features/Signals/Index.rst
+++ b/Documentation/Features/Signals/Index.rst
@@ -19,11 +19,11 @@ SignalSlots List
 
 
 .. t3-field-list-table::
- :header-rows: 1
+   :header-rows: 1
 
- - :File:
-      File
-   :Located:
+   -  :File:
+         File
+      :Located:
          Located in
       :Signal:
          Signal Name
@@ -32,7 +32,7 @@ SignalSlots List
       :Description:
          Description
 
-    - :File:
+   -  :File:
          NewController.php
       :Located:
          createAction()
@@ -43,7 +43,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process before the new user was persisted
 
-    - :File:
+   -  :File:
          NewController.php
       :Located:
          confirmCreateRequestAction()
@@ -54,7 +54,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the confirmation process
 
-    - :File:
+   -  :File:
          NewController.php
       :Located:
          createAdminConfirmationRequest()
@@ -65,7 +65,7 @@ SignalSlots List
       :Description:
          Signal if a user was auto-confirmed
 
-    - :File:
+   -  :File:
          NewController.php
       :Located:
          createAdminConfirmationRequest()
@@ -76,7 +76,7 @@ SignalSlots List
       :Description:
          Signal if a user was not auto-confirmed and must be confirmed manually
 
-    - :File:
+   -  :File:
          EditController.php
       :Located:
          updateAction()
@@ -87,7 +87,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process before the user- profile was updated
 
-    - :File:
+   -  :File:
          EditController.php
       :Located:
          confirmUpdateRequestAction()
@@ -98,7 +98,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook after a profile was accepted or refused
 
-    - :File:
+   -  :File:
          EditController.php
       :Located:
          deleteAction()
@@ -109,7 +109,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process before the user- profile will be deleted
 
-    - :File:
+   -  :File:
          InvitationController.php
       :Located:
          createAction()
@@ -120,7 +120,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process before a new user was persisted
 
-    - :File:
+   -  :File:
          InvitationController.php
       :Located:
          createAllConfirmed()
@@ -131,7 +131,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process after a new user was persisted
 
-    - :File:
+   -  :File:
          InvitationController.php
       :Located:
          editAction()
@@ -142,7 +142,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process before a user adds a new password (step 1)
 
-    - :File:
+   -  :File:
          InvitationController.php
       :Located:
          updateAction()
@@ -153,7 +153,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process after a user adds a new password (step 2)
 
-    - :File:
+   -  :File:
          UserController.php
       :Located:
          loginAsAction()
@@ -164,7 +164,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process after you simulate a frontend user login
 
-    - :File:
+   -  :File:
          UserBackendController.php
       :Located:
          confirmUserAction()
@@ -175,7 +175,7 @@ SignalSlots List
       :Description:
          Signal if a user profile was confirmed in backend module
 
-    - :File:
+   -  :File:
          UserBackendController.php
       :Located:
          refuseUserAction()
@@ -186,7 +186,7 @@ SignalSlots List
       :Description:
          Signal if a user profile was refused in backend module
 
-    - :File:
+   -  :File:
          AbstractController.php
       :Located:
          finalCreate()
@@ -197,7 +197,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process after the new user was persisted
 
-    - :File:
+   -  :File:
          AbstractController.php
       :Located:
          updateAllConfirmed()
@@ -208,7 +208,7 @@ SignalSlots List
       :Description:
          Use this signal if you want to hook into the process after the new user was persisted
 
-    - :File:
+   -  :File:
          ?
       :Located:
          ?

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -15,7 +15,7 @@ Femanager is a TYPO3 extension for a modern Frontend-User registration and profi
 		femanager
 
 	:Version:
-		5.0
+		5.0.1
 
 	:Language:
 		en
@@ -40,7 +40,7 @@ Table of Contents
 
 	Introduction/Index
 	Installation/Index
-   Upgrade/Index
+	Upgrade/Index
 	Features/Index
 	FAQ/Index
 
@@ -61,4 +61,4 @@ You can use one of the following links, to get more informations about this plug
 - All information about femanager developing, the developers behind femanager, etc...: https://github.com/in2code-de/femanager
 - femanager is powered by https://www.in2code.de
 - Do you need help from the community:
--- Slack channel #ext-femanager: https://typo3.slack.com/messages/C0NAHDRJB/
+    - Slack channel #ext-femanager: https://typo3.slack.com/messages/C0NAHDRJB/

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -2208,22 +2208,22 @@ You can overwrite these settings in your page TS.
 
 
 .. t3-field-list-table::
- :header-rows: 1
+   :header-rows: 1
 
- - :Tab:
-      Tab
-   :Field:
+   -  :Tab:
+         Tab
+      :Field:
          Field Name
       :Description:
          Description
       :Default:
          Default Value
- - :Tab:
-      	settings.configPID
-   :Field:
-      typoscript main template storage
-   :Description:
-      You need to specify the pid, where your main typoscript settings (frontend) is stored. Usually you will take the
-       root page of your installation.
-   :Default:
-      1
+   -  :Tab:
+         settings.configPID
+      :Field:
+         typoscript main template storage
+      :Description:
+         You need to specify the pid, where your main typoscript settings (frontend) is stored. Usually you will take the
+          root page of your installation.
+      :Default:
+         1

--- a/Documentation/Settings.yml
+++ b/Documentation/Settings.yml
@@ -6,8 +6,8 @@
 conf.py:
   copyright: 2013-2018
   project: Femanager
-  version: 4
-  release: 4.1
+  version: 5
+  release: 5.0.1
   latex_elements:
     papersize: a4paper
     pointsize: 10pt

--- a/Documentation/Upgrade/Index.rst
+++ b/Documentation/Upgrade/Index.rst
@@ -1,20 +1,20 @@
 .. include:: ../Includes.txt
 .. include:: Images.txt
 
-.. _installation:
+.. _upgrade:
 
 Upgrade
 =======
 
 .. only:: html
 
-	:ref:`guide` |
+	:ref:`v4` | :ref:`v5`
 
 
-.. _guide:
+.. _v4:
 
 to version 4.2.3 / 4.2.4 / 4.2.5
-------------
+--------------------------------
 
 If you use your own HTML templates of new/edit/invitation-templates you should compare them with the one from
 EXT:femanager. There is a new additional attribute inside the form viewhelper: data-femanager-plugin, which contains
@@ -22,6 +22,8 @@ the content element id.
 
 If you use a modified version of the Validation.js, there are also changes: plugin and action parameter is send to
 the eID-Script now
+
+.. _v5:
 
 to version 5
 ------------
@@ -34,15 +36,15 @@ In order that the js validation works, you need to take care, that you these pag
 1. Backend Module: Login as User feature
 
 ::
-feManagerLoginAs.typeNum = 1548943013
-::
+
+    feManagerLoginAs.typeNum = 1548943013
 
 see the complete config in file ext_typoscript_setup.txt
 
 2. Frontend Validation via JS
 
 ::
-feManagerLoginAs.typeNum = 1548935210
-::
+
+    feManagerLoginAs.typeNum = 1548935210
 
 see the complete config in file Configuration/TypoScript/setup.ext


### PR DESCRIPTION
This also brings back the sub-page "Features/ResendUserConfirmationRequest" which was not included anymore because of a typo in the file name.

Closes #135.