### PR TITLE
[TASK] Consistent naming for ConnectionPool method

### DIFF
--- a/Classes/DataProcessor/ImageManipulation.php
+++ b/Classes/DataProcessor/ImageManipulation.php
@@ -66,7 +66,7 @@ class ImageManipulation extends AbstractDataProcessor
             $properties[$field] = $value;
         }
 
-        $databaseConnectionForPages = ObjectUtility::getDatabaseConnection()->getConnectionForTable('sys_file_reference');
+        $databaseConnectionForPages = ObjectUtility::getConnectionPool()->getConnectionForTable('sys_file_reference');
         $databaseConnectionForPages->insert(
             'sys_file_reference',
             $properties

--- a/Classes/Utility/AbstractUtility.php
+++ b/Classes/Utility/AbstractUtility.php
@@ -36,10 +36,9 @@ abstract class AbstractUtility
 
     /**
      * @return ConnectionPool
-     * @SuppressWarnings(PHPMD.Superglobals)
      * @codeCoverageIgnore
      */
-    protected static function getDatabaseConnection()
+    public static function getConnectionPool()
     {
         return GeneralUtility::makeInstance(ConnectionPool::class);
     }

--- a/Classes/Utility/ObjectUtility.php
+++ b/Classes/Utility/ObjectUtility.php
@@ -18,15 +18,6 @@ class ObjectUtility extends AbstractUtility
 {
 
     /**
-     * @return ConnectionPool
-     * @codeCoverageIgnore
-     */
-    public static function getDatabaseConnection(): ConnectionPool
-    {
-        return parent::getDatabaseConnection();
-    }
-
-    /**
      * @param string $tableName
      * @return QueryBuilder
      */

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -273,7 +273,7 @@ class UserUtility extends AbstractUtility
      */
     public static function removeFrontendSessionToUser(User $user)
     {
-        self::getDatabaseConnection()->getConnectionForTable('fe_sessions')->delete(
+        self::getConnectionPool()->getConnectionForTable('fe_sessions')->delete(
             'fe_sessions', ['ses_userid' => (int)$user->getUid()]
         );
     }
@@ -286,7 +286,7 @@ class UserUtility extends AbstractUtility
      */
     public static function checkFrontendSessionToUser(User $user)
     {
-        $queryBuilder = self::getDatabaseConnection()->getQueryBuilderForTable('fe_sessions');
+        $queryBuilder = self::getConnectionPool()->getQueryBuilderForTable('fe_sessions');
 
         $row = $queryBuilder->select('ses_id')
             ->from('fe_sessions')


### PR DESCRIPTION
The method to get an instance of the ConnectionPool class has been
renamed from AbstractUtility::getDatabaseConnection() to
getConnectionPool() and made public (instead of extending its visibility
in AbstractUtility).