### PR TITLE
[BUGFIX] Wrong type for argument within CaptchaEnabledViewHelper

### DIFF
--- a/Classes/ViewHelpers/Misc/CaptchaEnabledViewHelper.php
+++ b/Classes/ViewHelpers/Misc/CaptchaEnabledViewHelper.php
@@ -17,7 +17,7 @@ class CaptchaEnabledViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
-        $this->registerArgument('settings', 'bool','array $settings TypoScript',true);
+        $this->registerArgument('settings', 'array', 'array $settings TypoScript', true);
     }
 
     /**


### PR DESCRIPTION
The argument settings was defined to be bool. Actually this is an array
and used as an array within ViewHelper.
Therefore the type was adjusted to be array.