### PR TITLE
Allow '0' if field is required

### DIFF
--- a/Classes/Domain/Validator/AbstractValidator.php
+++ b/Classes/Domain/Validator/AbstractValidator.php
@@ -59,6 +59,9 @@ abstract class AbstractValidator extends AbstractValidatorExtbase
     protected function validateRequired($value)
     {
         if (!is_object($value)) {
+            if (is_numeric($value)) {
+                return true;
+            }
             return !empty($value);
         } elseif ((is_array($value) || $value instanceof \Countable) && count($value) > 0) {
             return true;

--- a/Tests/Unit/Domain/Validator/AbstractValidatorTest.php
+++ b/Tests/Unit/Domain/Validator/AbstractValidatorTest.php
@@ -68,11 +68,11 @@ class AbstractValidatorTest extends UnitTestCase
             ],
             [
                 '0',
-                false
+                true
             ],
             [
                 0,
-                false
+                true
             ],
             [
                 null,


### PR DESCRIPTION
As 0 is a value, and not nothing.

Relates: https://github.com/in2code-de/femanager/issues/52