### PR TITLE
[BUGFIX] Take into account the option BE.flexformForceCDATA

### DIFF
--- a/Classes/Domain/Repository/PluginRepository.php
+++ b/Classes/Domain/Repository/PluginRepository.php
@@ -87,15 +87,10 @@ class PluginRepository
      */
     protected function isViewInPluginConfiguration(string $view, string $pluginConfiguration): bool
     {
+        $flexFormService = ObjectUtility::getObjectManager()->get(FlexFormService::class);
+        $flexFormArray = $flexFormService->convertFlexFormContentToArray($pluginConfiguration);
         if (array_key_exists($view, $this->scaString)) {
-            $viewString = $this->scaString[$view];
-            preg_match(
-                '~<field index="switchableControllerActions">\s+<value index="vDEF">'
-                    . htmlspecialchars($viewString) . '~',
-                $pluginConfiguration,
-                $result
-            );
-            return $result !== [];
+            return $this->scaString[$view] === $flexFormArray['switchableControllerActions'];
         } else {
             throw new \LogicException('Given view is not allowed', 1541506310);
         }


### PR DESCRIPTION
Use the FlexFormService in isViewInPluginConfiguration method rather than preg_match

Resolve: #177

To reproduce:
This issue happened with the edit view with the option BE.flexformForceCDATA set to true, with 3 languages I had to re-save all of them for the error to occur again.