### PR TITLE
do TCA migrations for TYPO3 v9.5

### DIFF
--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -30,8 +30,8 @@ $feUsersColumns = [
             'tx_femanager_domain_model_user.dateOfBirth',
         'config' => [
             'type' => 'input',
+            'renderType' => 'inputDateTime',
             'size' => 10,
-            'max' => 20,
             'eval' => 'date',
             'checkbox' => '0',
             'default' => 0
@@ -43,6 +43,7 @@ $feUsersColumns = [
             'fe_users.crdate',
         'config' => [
             'type' => 'input',
+            'renderType' => 'inputDateTime',
             'size' => 30,
             'eval' => 'datetime',
             'readOnly' => true,
@@ -55,6 +56,7 @@ $feUsersColumns = [
             'fe_users.tstamp',
         'config' => [
             'type' => 'input',
+            'renderType' => 'inputDateTime',
             'size' => 30,
             'eval' => 'datetime',
             'readOnly' => true,

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -95,6 +95,7 @@ $feUsersColumns = [
         'exclude' => true,
         'config' => [
             'type' => 'input',
+            'renderType' => 'inputDateTime',
             'size' => 30,
             'eval' => 'datetime',
             'readOnly' => true,

--- a/Configuration/TCA/tx_femanager_domain_model_log.php
+++ b/Configuration/TCA/tx_femanager_domain_model_log.php
@@ -9,8 +9,7 @@ return [
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',
         'dividers2tabs' => true,
-        'versioningWS' => 2,
-        'versioning_followPages' => true,
+        'versioningWS' => true,
         'origUid' => 't3_origuid',
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
@@ -90,34 +89,38 @@ return [
         ],
         'starttime' => [
             'exclude' => 1,
-            'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.starttime',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputDateTime',
                 'size' => 13,
-                'max' => 20,
                 'eval' => 'datetime',
                 'checkbox' => 0,
                 'default' => 0,
                 'range' => [
                     'lower' => mktime(0, 0, 0, date('m'), date('d'), date('Y'))
                 ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ]
             ],
         ],
         'endtime' => [
             'exclude' => 1,
-            'l10n_mode' => 'mergeIfNotBlank',
             'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.endtime',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputDateTime',
                 'size' => 13,
-                'max' => 20,
                 'eval' => 'datetime',
                 'checkbox' => 0,
                 'default' => 0,
                 'range' => [
                     'lower' => mktime(0, 0, 0, date('m'), date('d'), date('Y'))
                 ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ]
             ],
         ],
         'title' => [
@@ -135,6 +138,7 @@ return [
                 'tx_femanager_domain_model_log.crdate',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputDateTime',
                 'size' => 30,
                 'eval' => 'datetime',
                 'readOnly' => 1


### PR DESCRIPTION
As I checked the changed parts already apply for the TYPO3 v8.7 version.