### PR TITLE
Update AbstractController.php

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -35,37 +35,31 @@ abstract class AbstractController extends ActionController
 {
     /**
      * @var \In2code\Femanager\Domain\Repository\UserRepository
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $userRepository;
 
     /**
      * @var \In2code\Femanager\Domain\Repository\UserGroupRepository
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $userGroupRepository;
 
     /**
      * @var \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $persistenceManager;
 
     /**
      * @var \In2code\Femanager\Domain\Service\SendMailService
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $sendMailService;
 
     /**
      * @var \In2code\Femanager\Finisher\FinisherRunner
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $finisherRunner;
 
     /**
      * @var \In2code\Femanager\Utility\LogUtility
-     * @TYPO3\CMS\Extbase\Annotation\Inject
      */
     protected $logUtility;
 
@@ -118,6 +112,31 @@ abstract class AbstractController extends ActionController
      * @var object
      */
     public $allUserGroups;
+    
+    /**
+     * AbstractController constructor.
+     * @param \In2code\Femanager\Domain\Repository\UserRepository $userRepository
+     * @param \In2code\Femanager\Domain\Repository\UserGroupRepository $userGroupRepository
+     * @param \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager $persistenceManager
+     * @param \In2code\Femanager\Domain\Service\SendMailService $sendMailService
+     * @param \In2code\Femanager\Finisher\FinisherRunner $finisherRunner
+     * @param \In2code\Femanager\Utility\LogUtility $logUtility
+     */
+    public function __construct(
+        \In2code\Femanager\Domain\Repository\UserRepository $userRepository,
+        \In2code\Femanager\Domain\Repository\UserGroupRepository $userGroupRepository,
+        \TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager $persistenceManager,
+        \In2code\Femanager\Domain\Service\SendMailService $sendMailService,
+        \In2code\Femanager\Finisher\FinisherRunner $finisherRunner,
+        \In2code\Femanager\Utility\LogUtility $logUtility
+    ) {
+        $this->userRepository = $userRepository;
+        $this->userGroupRepository = $userGroupRepository;
+        $this->persistenceManager = $persistenceManager;
+        $this->sendMailService = $sendMailService;
+        $this->finisherRunner = $finisherRunner;
+        $this->logUtility = $logUtility;
+    }
 
     /**
      * Prefix method to createAction()


### PR DESCRIPTION
Extending New/EditController will not working in TYPO3 10.4.x  because of deprecated DI notation.