### PR TITLE
[BUGFIX] Allow frontend user login via EXT:femanager

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -44,16 +44,6 @@ class ConfigurationUtility extends AbstractUtility
     }
 
     /**
-     * @return bool
-     */
-    public static function isSetCookieOnLoginActive(): bool
-    {
-        $configuration = self::getExtensionConfiguration();
-
-        return $configuration['setCookieOnLogin'] === '1';
-    }
-
-    /**
      * Get complete Typoscript or only a special value by a given path
      *
      * @param string $path "misc.uploadFolder" or empty for complete TypoScript array

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -344,30 +344,11 @@ class UserUtility extends AbstractUtility
      */
     public static function login(User $user, $storagePids = null)
     {
-        #Log in user
-        $GLOBALS['TSFE']->fe_user->createUserSession(['uid' => (int)$user->getUid()]);
-        $GLOBALS['TSFE']->fe_user->loginSessionStarted = 1;
-        $GLOBALS['TSFE']->fe_user->forceSetCookie = true;
-        $GLOBALS['TSFE']->fe_user->dontSetCookie = false;
-        $GLOBALS['TSFE']->fe_user->start();
+        // ensure a session cookie is set (in case there is no session yet)
         $GLOBALS['TSFE']->fe_user->setAndSaveSessionData('dummy', true);
-        $GLOBALS['TSFE']->fe_user->loginUser = 1;
-    }
-
-    /**
-     * This is a dirty solution to get autologin to work see https://github.com/in2code-de/femanager/issues/27 for
-     * details on this issue
-     *
-     * @param TypoScriptFrontendController $tsfe
-     * @return void
-     */
-    protected static function loginAlternative(TypoScriptFrontendController $tsfe)
-    {
-        if (ConfigurationUtility::isSetCookieOnLoginActive()) {
-            $reflection = new \ReflectionClass($tsfe->fe_user);
-            $setSessionCookie = $reflection->getMethod('setSessionCookie');
-            $setSessionCookie->setAccessible(true);
-            $setSessionCookie->invoke($tsfe->fe_user);
-        }
+        // create the session (destroys all existing session data in the session backend!)
+        $GLOBALS['TSFE']->fe_user->createUserSession(['uid' => (int)$user->getUid()]);
+        // write the session data again to the session backend; preserves what was there before!!
+        $GLOBALS['TSFE']->fe_user->setAndSaveSessionData('dummy', true);
     }
 }

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -89,15 +89,6 @@ Settings
    :Default:
       0
 
- - :Property:
-      setCookieOnLogin
-   :Datatype:
-      boolean
-   :Description:
-      Set cookie on login (experimental): On some cases it could happen, that auto login after creation in frontend or simulate login from backend module does not work. This flag will turn on setCookie as an alternative (experimental see https://github.com/in2code-de/femanager/issues/27 for details)
-   :Default:
-      0
-
 Plugin Configuration
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/Tests/Unit/Utility/ConfigurationUtilityTest.php
+++ b/Tests/Unit/Utility/ConfigurationUtilityTest.php
@@ -63,20 +63,4 @@ class ConfigurationUtilityTest extends UnitTestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['femanager'] = $configuration;
         $this->assertTrue(ConfigurationUtility::isDisableLogActive());
     }
-
-    /**
-     * @return void
-     * @SuppressWarnings(PHPMD.Superglobals)
-     * @covers ::isSetCookieOnLoginActive
-     * @covers \In2code\Femanager\Utility\AbstractUtility::getExtensionConfiguration
-     */
-    public function testIsSetCookieOnLoginActive()
-    {
-        $configuration = [
-            'setCookieOnLogin' => '1'
-        ];
-        // @extensionScannerIgnoreLine
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['femanager'] = $configuration;
-        $this->assertTrue(ConfigurationUtility::isSetCookieOnLoginActive());
-    }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -7,8 +7,5 @@ enableConfirmationModule = 0
 # cat=basic/enable/030; type=boolean; label= Disable Log: If you don't want to save each change of an fe_user, you can disable the logfile
 disableLog = 0
 
-# cat=basic/enable/100; type=boolean; label= Set cookie on login (experimental): On some cases it could happen, that auto login after creation in frontend or simulate login from backend module does not work. This flag will turn on setCookie as an alternative (experimental see https://github.com/in2code-de/femanager/issues/27 for details)
-setCookieOnLogin = 0
-
 # cat=basic/enable/200; type=boolean; label= Replace the input field for a fe_user's country with a select box.: This feature can be active without static_info_tables, but will use data from static_info_tables if it is installed.
 overrideFeUserCountryFieldWithSelect = 0


### PR DESCRIPTION
Resolves: #272

Also cleans up code related to obsolete option `setCookieOnLogin`.