### PR TITLE
[TASK] Use country short name instead of official name by default

### DIFF
--- a/Classes/DataProvider/CountryDataProvider.php
+++ b/Classes/DataProvider/CountryDataProvider.php
@@ -19,6 +19,6 @@ class CountryDataProvider
     /** @return Country[] */
     public function getCountries(): array
     {
-        return $this->countryRepository->findAllOrderedBy('officialNameEn')->toArray();
+        return $this->countryRepository->findAllOrderedBy('shortNameLocal')->toArray();
     }
 }

--- a/Classes/UserFunc/StaticInfoTables.php
+++ b/Classes/UserFunc/StaticInfoTables.php
@@ -59,7 +59,7 @@ class StaticInfoTables
             $countryDataProvider = GeneralUtility::makeInstance(CountryDataProvider::class);
             $countries = $countryDataProvider->getCountries();
             foreach ($countries as $country) {
-                $data['items'][] = [$country->getOfficialNameEn(), $country->getIsoCodeA3()];
+                $data['items'][] = [$country->getShortNameEn(), $country->getIsoCodeA3()];
             }
         } else {
             $fallbackCountryDataProvider = GeneralUtility::makeInstance(FallbackCountryDataProvider::class);

--- a/Classes/ViewHelpers/Form/GetCountriesFromStaticInfoTablesViewHelper.php
+++ b/Classes/ViewHelpers/Form/GetCountriesFromStaticInfoTablesViewHelper.php
@@ -52,8 +52,8 @@ class GetCountriesFromStaticInfoTablesViewHelper extends AbstractViewHelper
     {
         parent::initializeArguments();
         $this->registerArgument('key', 'string', 'country isoCode', false, 'isoCodeA3');
-        $this->registerArgument('value', 'string', 'officialNameLocal', false, 'officialNameLocal');
-        $this->registerArgument('sortbyField', 'string', 'isoCodeA3', false, 'isoCodeA3');
+        $this->registerArgument('value', 'string', 'shortNameLocal', false, 'shortNameLocal');
+        $this->registerArgument('sortbyField', 'string', 'shortNameLocal', false, 'shortNameLocal');
         $this->registerArgument('sorting', 'string', 'value to prepend', false, 'asc');
     }
 }


### PR DESCRIPTION
… name by default

It's easier for FE Users to find their country if the list displays the countries short name localized instead of official name. Eg.:
"United Kingdom" instead of "United Kingdom of Great Britain and Northern"
"Deutschland" instead of "Bundesrepublik Deutschland"
"Italia" instead of "Repubblica Italiana"

Also, it's easier for a BE editor to find a country in a long list if countries are displayed with their short name instead of official name.