### PR TITLE
[BUGFIX] Use getter for userTS

### DIFF
--- a/Classes/Utility/BackendUserUtility.php
+++ b/Classes/Utility/BackendUserUtility.php
@@ -17,7 +17,7 @@ class BackendUserUtility extends AbstractUtility
     {
         $userAuthentication = self::getBackendUserAuthentication();
 
-        return $userAuthentication->user['admin'] === 1 || (int)$userAuthentication->userTS['tx_femanager.']['UserBackend.']['enableLoginAs'] === 1;
+        return $userAuthentication->user['admin'] === 1 || (int)$userAuthentication->getTSConfig()['tx_femanager.']['UserBackend.']['enableLoginAs'] === 1;
     }
 
     /**


### PR DESCRIPTION
The property userTS of the Class TYPO3\CMS\Core\Authentication\BackendUserAuthentication is now protected.
So we have to use the provided getter.