### PR TITLE
Use ObjectManager to instantiate CountryDataProvider

### DIFF
--- a/Classes/UserFunc/StaticInfoTables.php
+++ b/Classes/UserFunc/StaticInfoTables.php
@@ -58,7 +58,8 @@ class StaticInfoTables
     public function getCountryOptions(array $data, TcaSelectItems $tcaSelectItems)
     {
         if (ExtensionManagementUtility::isLoaded('static_info_tables')) {
-            $countryDataProvider = GeneralUtility::makeInstance(CountryDataProvider::class);
+            $countryDataProvider = GeneralUtility::makeInstance(ObjectManager::class)
+                ->get(CountryDataProvider::class);
             $countries = $countryDataProvider->getCountries();
             foreach ($countries as $country) {
                 $data['items'][] = [$country->getOfficialNameEn(), $country->getIsoCodeA3()];


### PR DESCRIPTION
This fixes the error
```
Too few arguments to function In2code\Femanager\DataProvider\CountryDataProvider::__construct()
...
at TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('In2code\\Femanager\\DataProvider\\CountryDataProvider')
in /var/www/html/src/public/typo3conf/ext/femanager/Classes/UserFunc/StaticInfoTables.php line 61
```
with `basic.overrideFeUserCountryFieldWithSelect` in the extension settings is set when accessing an fe_user record in the backend.

Since `CountryDataProvider` relies on inject*(), it still needs the `ObjectManager` in TYPO3 v9.

