### PR TITLE
Use USER_INT instead of no_cache for better performance

### DIFF
--- a/Configuration/TypoScript/Main/setup.txt
+++ b/Configuration/TypoScript/Main/setup.txt
@@ -1689,7 +1689,7 @@ feManagerValidation {
 	typeNum = 1548935210
 	config {
 		additionalHeaders.10.header = Content-Type: application/json
-		no_cache = 1
+		no_cache = 0
 		disableAllHeaderCode = 1
 		disablePrefixComment = 1
 		xhtml_cleaning = 0
@@ -1697,7 +1697,7 @@ feManagerValidation {
 		debug = 0
 	}
 
-	10 = USER
+	10 = USER_INT
 	10 {
 		userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
 		extensionName = Femanager
@@ -1715,7 +1715,7 @@ feManagerStateSelection {
 	typeNum = 1594138042
 	config {
 		additionalHeaders.10.header = Content-Type: application/json
-		no_cache = 1
+		no_cache = 0
 		disableAllHeaderCode = 1
 		disablePrefixComment = 1
 		xhtml_cleaning = 0
@@ -1723,7 +1723,7 @@ feManagerStateSelection {
 		debug = 0
 	}
 
-	10 = USER
+	10 = USER_INT
 	10 {
 		userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
 		extensionName = Femanager


### PR DESCRIPTION
Seems that scenario with `config.no_cache` causes waiting for cache locks when multiple concurrent users are calling the script.
I did a simple test with siege, and 10 concurrent users, and got almost 5x faster results.

It would be cool, if somebody could rerun the tests on his side to validate my findings.