### PR TITLE
Missing error fields

### DIFF
--- a/Classes/Domain/Validator/ServersideValidator.php
+++ b/Classes/Domain/Validator/ServersideValidator.php
@@ -217,7 +217,7 @@ class ServersideValidator extends AbstractValidator
             $validationSetting === '1' &&
             !$this->validateUniqueDb($value, $fieldName, $user)
         ) {
-            $this->addError('validationErrorUniqueDb', $fieldName);
+            $this->addError('validationErrorUniqueDb', 0, ['code' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -231,7 +231,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMustIncludeValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMustInclude($value, $validationSetting)) {
-            $this->addError('validationErrorMustInclude', $fieldName);
+            $this->addError('validationErrorMustInclude', 0, ['code' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -245,7 +245,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMustNotIncludeValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMustNotInclude($value, $validationSetting)) {
-            $this->addError('validationErrorMustNotInclude', $fieldName);
+            $this->addError('validationErrorMustNotInclude', 0, ['code' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -259,7 +259,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkInListValidation($value, $validationSetting, $fieldName)
     {
         if (!$this->validateInList($value, $validationSetting)) {
-            $this->addError('validationErrorInList', $fieldName);
+            $this->addError('validationErrorInList', 0, ['code' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -276,7 +276,7 @@ class ServersideValidator extends AbstractValidator
         if (method_exists($user, 'get' . ucfirst($validationSetting))) {
             $valueToCompare = $user->{'get' . ucfirst($validationSetting)}();
             if (!$this->validateSameAs($value, $valueToCompare)) {
-                $this->addError('validationErrorSameAs', $fieldName);
+                $this->addError('validationErrorSameAs', 0, ['code' => $fieldName]);
                 $this->isValid = false;
             }
         }
@@ -293,7 +293,7 @@ class ServersideValidator extends AbstractValidator
     {
         if (method_exists($this, 'validate' . ucfirst($validation))) {
             if (!$this->{'validate' . ucfirst($validation)}($value, $validationSetting)) {
-                $this->addError('validationError' . ucfirst($validation), $fieldName);
+                $this->addError('validationError' . ucfirst($validation), 0, ['code' => $fieldName]);
                 $this->isValid = false;
             }
         }

--- a/Resources/Private/Templates/Edit/ConfirmUpdateRequest.html
+++ b/Resources/Private/Templates/Edit/ConfirmUpdateRequest.html
@@ -7,6 +7,6 @@
 
 	<f:section name="main">
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-		<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+		<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 	</f:section>
 </div>

--- a/Resources/Private/Templates/Edit/Edit.html
+++ b/Resources/Private/Templates/Edit/Edit.html
@@ -9,7 +9,7 @@
 
 	<f:section name="main">
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-		<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+		<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 
 		<div class="femanager_edit">
 			<f:if condition="{user}">

--- a/Resources/Private/Templates/Invitation/Edit.html
+++ b/Resources/Private/Templates/Invitation/Edit.html
@@ -8,7 +8,7 @@ Available variables:
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-	<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 
 	<div class="femanager_invitation_edit">
 		<f:if condition="{user}">

--- a/Resources/Private/Templates/Invitation/New.html
+++ b/Resources/Private/Templates/Invitation/New.html
@@ -11,7 +11,7 @@ Invitation / New
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-	<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 
 	<div class="femanager_invitation_new">
 		<f:form

--- a/Resources/Private/Templates/New/New.html
+++ b/Resources/Private/Templates/New/New.html
@@ -8,7 +8,7 @@
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-	<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 	<f:render partial="Misc/ResendConfirmation" arguments="{_all}" />
 	<div class="femanager_new">
 		<f:form

--- a/Resources/Private/Templates/New/ResendConfirmationDialogue.html
+++ b/Resources/Private/Templates/New/ResendConfirmationDialogue.html
@@ -4,7 +4,7 @@ User / Status
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}"/>
-	<f:render partial="Misc/FormErrors" arguments="{object:User}"/>
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}"/>
 	<div class="femanager_new">
 		<h3>
 			<f:translate key="resendConfirmationMailTitle">Resend confirmation mail</f:translate>


### PR DESCRIPTION
To fixes:
* Add property information to all errors;
* Fix passing object name to `FormErrors` partial, a non-existant var was passed instead of the var name;