### PR TITLE
[BUGFIX] Template missing for New->create

### DIFF
--- a/Classes/Controller/NewController.php
+++ b/Classes/Controller/NewController.php
@@ -64,6 +64,9 @@ class NewController extends AbstractController
         } else {
             $this->createRequest($user);
         }
+
+        // Redirect as fallback for there's no Templates/New/Create.html
+        $this->redirect('createStatus');
     }
 
     /**


### PR DESCRIPTION
This fixes the error below that occurs when after creating a new user but not having specified a redirect via TS for that action.

Patch is applicable for version 5.4.2.

 ```
Sorry, the requested view was not found.

No template was found. View could not be resolved for action 
"create" in class "In2code\Femanager\Controller\NewController".
```

Related: #295, #299