### PR TITLE
Migration Breaking: #92609 v11.0

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,21 +6,21 @@ if (!defined('TYPO3_MODE')) {
 call_user_func(function () {
 
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'In2code.femanager',
+        'femanager',
         'Pi1',
         [
-            'User' => 'list, show, validate, loginAs, imageDelete',
-            'New' => 'new, create, confirmCreateRequest, createStatus, resendConfirmationMail, resendConfirmationDialogue',
-            'Edit' => 'edit, update, delete, confirmUpdateRequest',
-            'Invitation' => 'new, create, edit, update, delete, status',
-            'Data' => 'getStatesForCountry'
+            \In2code\Femanager\Controller\UserController::class => 'list, show, validate, loginAs, imageDelete',
+            \In2code\Femanager\Controller\NewController::class => 'new, create, confirmCreateRequest, createStatus, resendConfirmationMail, resendConfirmationDialogue',
+            \In2code\Femanager\Controller\EditController::class => 'edit, update, delete, confirmUpdateRequest',
+            \In2code\Femanager\Controller\InvitationController::class => 'new, create, edit, update, delete, status',
+            \In2code\Femanager\Controller\DataController::class => 'getStatesForCountry'
         ],
         [
-            'User' => 'list, show, validate, loginAs, imageDelete',
-            'New' => 'new, create, confirmCreateRequest, createStatus, resendConfirmationMail, resendConfirmationDialogue',
-            'Edit' => 'edit, update, delete, confirmUpdateRequest',
-            'Invitation' => 'new, create, edit, update, delete',
-            'Data' => 'getStatesForCountry'
+            \In2code\Femanager\Controller\UserController::class => 'list, show, validate, loginAs, imageDelete',
+            \In2code\Femanager\Controller\NewController::class => 'new, create, confirmCreateRequest, createStatus, resendConfirmationMail, resendConfirmationDialogue',
+            \In2code\Femanager\Controller\EditController::class => 'edit, update, delete, confirmUpdateRequest',
+            \In2code\Femanager\Controller\InvitationController::class => 'new, create, edit, update, delete',
+            \In2code\Femanager\Controller\DataController::class => 'getStatesForCountry'
         ]
     );
 


### PR DESCRIPTION
Migration Breaking: #92609 v11.0 - Use controller classes when registering plugins/modules