### PR TITLE
[BUGFIX] Fix field validation messages

### DIFF
--- a/Classes/Domain/Validator/PasswordValidator.php
+++ b/Classes/Domain/Validator/PasswordValidator.php
@@ -67,7 +67,7 @@ class PasswordValidator extends AbstractValidatorExtbase
         $passwordRepeat = isset($this->piVars['password_repeat']) ? $this->piVars['password_repeat'] : '';
 
         if ($password !== $passwordRepeat) {
-            $this->addError('validationErrorPasswordRepeat', 0, ['code' => 'password']);
+            $this->addError('validationErrorPasswordRepeat', 0, ['field' => 'password']);
             return false;
         }
 

--- a/Classes/Domain/Validator/ServersideValidator.php
+++ b/Classes/Domain/Validator/ServersideValidator.php
@@ -108,7 +108,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkRequiredValidation($validationSetting, $value, $fieldName)
     {
         if ($validationSetting === '1' && !$this->validateRequired($value)) {
-            $this->addError('validationErrorRequired', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorRequired', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -121,7 +121,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkEmailValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && $validationSetting === '1' && !$this->validateEmail($value)) {
-            $this->addError('validationErrorEmail', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorEmail', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -134,7 +134,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMinValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMin($value, $validationSetting)) {
-            $this->addError('validationErrorMin', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorMin', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -147,7 +147,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMaxValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMax($value, $validationSetting)) {
-            $this->addError('validationErrorMax', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorMax', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -160,7 +160,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkIntOnlyValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && $validationSetting === '1' && !$this->validateInt($value)) {
-            $this->addError('validationErrorInt', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorInt', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -173,7 +173,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkLetterOnlyValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && $validationSetting === '1' && !$this->validateLetters($value)) {
-            $this->addError('validationErrorLetters', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorLetters', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -186,7 +186,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkUnicodeLetterOnlyValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && $validationSetting === '1' && !$this->validateUnicodeLetters($value)) {
-            $this->addError('validationErrorLetters', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorLetters', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -204,7 +204,7 @@ class ServersideValidator extends AbstractValidator
             $validationSetting === '1' &&
             !$this->validateUniquePage($value, $fieldName, $user)
         ) {
-            $this->addError('validationErrorUniquePage', 0, ['code' => $fieldName]);
+            $this->addError('validationErrorUniquePage', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -222,7 +222,7 @@ class ServersideValidator extends AbstractValidator
             $validationSetting === '1' &&
             !$this->validateUniqueDb($value, $fieldName, $user)
         ) {
-            $this->addError('validationErrorUniqueDb', $fieldName);
+            $this->addError('validationErrorUniqueDb', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -235,7 +235,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMustIncludeValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMustInclude($value, $validationSetting)) {
-            $this->addError('validationErrorMustInclude', $fieldName);
+            $this->addError('validationErrorMustInclude', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -248,7 +248,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkMustNotIncludeValidation($value, $validationSetting, $fieldName)
     {
         if (!empty($value) && !$this->validateMustNotInclude($value, $validationSetting)) {
-            $this->addError('validationErrorMustNotInclude', $fieldName);
+            $this->addError('validationErrorMustNotInclude', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -261,7 +261,7 @@ class ServersideValidator extends AbstractValidator
     protected function checkInListValidation($value, $validationSetting, $fieldName)
     {
         if (!$this->validateInList($value, $validationSetting)) {
-            $this->addError('validationErrorInList', $fieldName);
+            $this->addError('validationErrorInList', 0, ['field' => $fieldName]);
             $this->isValid = false;
         }
     }
@@ -277,7 +277,7 @@ class ServersideValidator extends AbstractValidator
         if (method_exists($user, 'get' . ucfirst($validationSetting))) {
             $valueToCompare = $user->{'get' . ucfirst($validationSetting)}();
             if (!$this->validateSameAs($value, $valueToCompare)) {
-                $this->addError('validationErrorSameAs', $fieldName);
+                $this->addError('validationErrorSameAs', 0, ['field' => $fieldName]);
                 $this->isValid = false;
             }
         }
@@ -293,7 +293,7 @@ class ServersideValidator extends AbstractValidator
     {
         if (method_exists($this, 'validate' . ucfirst($validation))) {
             if (!$this->{'validate' . ucfirst($validation)}($value, $validationSetting)) {
-                $this->addError('validationError' . ucfirst($validation), $fieldName);
+                $this->addError('validationError' . ucfirst($validation), 0, ['field' => $fieldName]);
                 $this->isValid = false;
             }
         }

--- a/Resources/Private/Partials/Misc/FormErrors.html
+++ b/Resources/Private/Partials/Misc/FormErrors.html
@@ -28,8 +28,8 @@
 										<f:comment>
 											If a validator check (see TypoScript) failed
 										</f:comment>
-										<f:translate key="tx_femanager_domain_model_user.{error.arguments.code}" />:
-										<f:format.printf arguments="{0: '{fieldname -> f:translate(key:\'tx_femanager_domain_model_user.{error.arguments.code}\')}'}">
+										<f:translate key="tx_femanager_domain_model_user.{error.arguments.field}" />:
+										<f:format.printf arguments="{0: '{fieldname -> f:translate(key:\'tx_femanager_domain_model_user.{error.arguments.field}\')}'}">
 											<f:translate key="{error.message}">{error.message}</f:translate>
 										</f:format.printf>
 									</f:else>

--- a/Resources/Private/Partials/Misc/ResendConfirmation.html
+++ b/Resources/Private/Partials/Misc/ResendConfirmation.html
@@ -1,7 +1,7 @@
 <f:form.validationResults>
 	<f:if condition="{validationResults.flattenedErrors} && {settings.showResendUserConfirmationRequestView} > 0">
 		<f:for each="{validationResults.flattenedErrors.user}" as="error">
-			<f:if condition="{error.code} =='username' && {error.message}=='validationErrorUniqueDb'">
+			<f:if condition="{error.arguments.field} =='username' && {error.message}=='validationErrorUniqueDb'">
 				<ul class="femanager_note">
 					<li>
 						<f:translate key="resendConfirmationDialogueMessage"/>&nbsp;


### PR DESCRIPTION
This fixes the output of field names in error messages.

Additionally, the argument name for a field in an error message was changed from 'code' to 'field'.

Resolves: #368