### PR TITLE
Fix exception when generating changeRequest XML where the oldProperty is null and newProperty is a DateTime

### DIFF
--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -246,18 +246,22 @@ class UserUtility extends AbstractUtility
                 && !in_array($propertyName, $ignoreProperties)
             ) {
                 $newPropertyValue = $changedObject->{'get' . ucfirst($propertyName)}();
-                if (!is_object($oldPropertyValue) || !is_object($newPropertyValue)) {
+                if (!is_object($oldPropertyValue) && !is_object($newPropertyValue)) {
                     if ($oldPropertyValue !== $newPropertyValue) {
                         $dirtyProperties[$propertyName]['old'] = $oldPropertyValue;
                         $dirtyProperties[$propertyName]['new'] = $newPropertyValue;
                     }
                 } else {
-                    if (get_class($oldPropertyValue) === 'DateTime') {
+                    if (($oldPropertyValue != null && get_class($oldPropertyValue) === 'DateTime') || ($newPropertyValue != null && get_class($newPropertyValue) === 'DateTime')) {
                         /** @var $oldPropertyValue \DateTime */
                         /** @var $newPropertyValue \DateTime */
-                        if ($oldPropertyValue->getTimestamp() !== $newPropertyValue->getTimestamp()) {
-                            $dirtyProperties[$propertyName]['old'] = $oldPropertyValue->getTimestamp();
-                            $dirtyProperties[$propertyName]['new'] = $newPropertyValue->getTimestamp();
+
+                        $oldTimestamp = $oldPropertyValue != null ? $oldPropertyValue->getTimestamp() : 0;
+                        $newTimestamp = $newPropertyValue != null ? $newPropertyValue->getTimestamp() : 0;
+
+                        if ($oldTimestamp !== $newTimestamp) {
+                            $dirtyProperties[$propertyName]['old'] = $oldTimestamp;
+                            $dirtyProperties[$propertyName]['new'] = $newTimestamp;
                         }
                     } else {
                         $titlesOld = ObjectUtility::implodeObjectStorageOnProperty($oldPropertyValue);


### PR DESCRIPTION
When the old or new value of a property is null while the other value is an object, an Exception is thrown in `GeneralUtility::array2xml`.

I fixed that issue, so that no objects are included in the return array anymore.

Additionally when the property value is `null`, `0` is returned instead of the timestamp.