### PR TITLE
[BUGFIX] Email subject for sendCreateUserConfirmationMail

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -522,7 +522,10 @@ abstract class AbstractController extends ActionController
                 $this->config['new.']['email.']['createUserConfirmation.']['sender.']['email.']['value'] =>
                     $this->config['new.']['email.']['createUserConfirmation.']['sender.']['name.']['value']
             ],
-            $this->settings['new']['email']['createUserConfirmation']['subject']['data'],
+            $this->contentObject->cObjGetSingle(
+                $this->config['new.']['email.']['createUserConfirmation.']['subject'],
+                $this->config['new.']['email.']['createUserConfirmation.']['subject.']
+            ),
             [
                 'user' => $user,
                 'hash' => HashUtility::createHashForUser($user)


### PR DESCRIPTION
Reverts 51debb9c9e568892b2d2157d21358a341a7a2224 and renders the cObj from TypoScript instead. `\In2code\Femanager\Domain\Service\SendMailService::send()` requires the fourth argument to be string.

Fixes #390