### PR TITLE
Fix embedded images in emails

### DIFF
--- a/Classes/Domain/Service/SendMailService.php
+++ b/Classes/Domain/Service/SendMailService.php
@@ -8,11 +8,9 @@ use In2code\Femanager\Utility\ObjectUtility;
 use In2code\Femanager\Utility\TemplateUtility;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mime\Part\DataPart;
-use Symfony\Component\Mime\Part\TextPart;
 use TYPO3\CMS\Core\Mail\Mailer;
 use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 /**
  * Class SendMailService


### PR DESCRIPTION
This should fix #311 and #343.

Symfony Email class no longer returns the cid:abc123 identifier for
the inline attachment from embedFromPath. Instead we can control the
cid identifier by setting the embed part name.

Another issue was that prepareMailObject replaced the body object of
the Email with its own TextPart object. This is incorrect, as the
body should be a Multipart object that contains the html/text as
well as the embedded images. If we do not setBody ourselves, but
keep to just setting html, the Email object will generate the right
body object itself.

See [\Symfony\Component\Mime\Email::generateBody](https://github.com/symfony/mime/blob/ae887cb3b044658676129f5e97aeb7e9eb69c2d8/Email.php#L411)

### How to test this PR

Add a TypoScript configuration to embed an image, then reference it
in the Fluid template for the email. 

TypoScript:
```
plugin.tx_femanager.settings.new.email.createUserConfirmation {
  embedImage = COA
  embedImage.0 = TEXT
  embedImage.0.value = fileadmin/image.jpg
}
``` 

Fluid template `Templates/Email/CreateUserConfirmation.html`:
```
<img src="{embedImages.0}" />
```

Set the registration plugin configuration to require the user to confirm their email address.

Create a new user account, receive an email, see image embedded in email.
