### PR TITLE
Fix refusing users from the admin confirmation backend list. fixes #378

### DIFF
--- a/Classes/Controller/UserBackendController.php
+++ b/Classes/Controller/UserBackendController.php
@@ -117,9 +117,8 @@ class UserBackendController extends AbstractController
 
         $user = $this->userRepository->findByUid($userIdentifier);
         $this->eventDispatcher->dispatch(new RefuseUserEvent($user));
-        $this->userRepository->remove($user);
 
-        $jsonResult = $this->getFrontendRequestResult('adminConfirmationRefused');
+        $jsonResult = $this->getFrontendRequestResult('adminConfirmationRefused', $userIdentifier, $user);
 
         if ($jsonResult['status'] ?? false) {
             $this->addFlashMessage(


### PR DESCRIPTION
The function `UserBackendController::getFrontendRequest` was introduced in 8167dd4a550603c1fc211ebe8d920050fa0f7e75 but applied incorrectly in the `refuseUserAction`. 

In addition to adding the missing arguments, I remove the call to `userRepository->remove()` 
because the function `NewController::statusAdminConfirmationRefused` already removes the user
when the frontend request succeeds.