### PR TITLE
[TASK] Remove TCA configuration showRecordFieldList

### DIFF
--- a/Configuration/TCA/tx_femanager_domain_model_log.php
+++ b/Configuration/TCA/tx_femanager_domain_model_log.php
@@ -24,9 +24,6 @@ return [
         'searchFields' => 'title',
         'iconfile' => 'EXT:femanager/Resources/Public/Icons/Log.png'
     ],
-    'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, crdate, state, user',
-    ],
     'types' => [
         '1' => [
             'showitem' => 'title, crdate, state, user, ' .


### PR DESCRIPTION
The TCA configuration `showRecordFieldList` inside the section `interface` is not evaluated anymore and all occurrences have been removed.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.3/Feature-88901-RenderAllFieldsInElementInformationController.html