### PR TITLE
[BUGFIX] no custom controller needed in TYPO3 10

### DIFF
--- a/Documentation/Features/NewFields/Index.rst
+++ b/Documentation/Features/NewFields/Index.rst
@@ -212,39 +212,11 @@ Example Model User.php which extends to the default femanager Model:
 		}
 
 	}
-
-
-TypoScript to include Model and override default controller with TYPO3 9.5.x
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-.. code-block:: text
-
-	config.tx_extbase{
-		persistence{
-			classes{
-				In2code\Femanager\Domain\Model\User {
-					subclasses {
-						0 = In2code\Femanagerextended\Domain\Model\User
-					}
-				}
-				In2code\Femanagerextended\Domain\Model\User {
-					mapping {
-						tableName = fe_users
-						recordType = 0
-					}
-				}
-			}
-		}
-		objects {
-			In2code\Femanager\Controller\NewController.className = In2code\Femanagerextended\Controller\NewController
-			In2code\Femanager\Controller\EditController.className = In2code\Femanagerextended\Controller\EditController
-		}
-	}
    
    
    
-Include model and override default controller with TYPO3 10.4.x
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Include model with TYPO3 10.4.x
+"""""""""""""""""""""""""""""""
 
 Configuration/Extbase/Persistence/Classes.php:
 
@@ -277,17 +249,41 @@ ext_localconf.php:
   
    $extbaseObjectContainer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\Object\Container\Container::class);
    $extbaseObjectContainer->registerImplementation(
-       \In2code\Femanager\Controller\NewController::class,
-       \In2code\Femanagerextended\Controller\NewController::class
-   );
-   $extbaseObjectContainer->registerImplementation(
-       \In2code\Femanager\Controller\EditController::class,
-       \In2code\Femanagerextended\Controller\EditController::class
+       \In2code\Femanager\Domain\Model\User::class,
+       \In2code\Femanagerextended\Domain\Model\User::class
    );
 
 
-Own Controller Files
-""""""""""""""""""""
+TypoScript to include Model and override default controller with TYPO3 9.5.x
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: text
+
+	config.tx_extbase{
+		persistence{
+			classes{
+				In2code\Femanager\Domain\Model\User {
+					subclasses {
+						0 = In2code\Femanagerextended\Domain\Model\User
+					}
+				}
+				In2code\Femanagerextended\Domain\Model\User {
+					mapping {
+						tableName = fe_users
+						recordType = 0
+					}
+				}
+			}
+		}
+		objects {
+			In2code\Femanager\Controller\NewController.className = In2code\Femanagerextended\Controller\NewController
+			In2code\Femanager\Controller\EditController.className = In2code\Femanagerextended\Controller\EditController
+		}
+	}
+
+
+Own Controller Files with TYPO3 9.5.x
+"""""""""""""""""""""""""""""""""""""
 
 EditController.php:
 
@@ -382,54 +378,3 @@ NewController.php:
 			parent::createAction($user);
 		}
 	}
-
-Own Controller Files with PHP 7.4 / TYPO3 10.4.x
-"""""""""""""""""""""""""""""""""""""""""""""""
-
-EditController.php:
-
-.. code-block:: text
-
-   namespace In2code\Femanagerextended\Controller;
-
-   use In2code\Femanager\Controller\EditController as FemanagerEditController;
-
-   class EditController extends FemanagerEditController
-   {
-       /**
-        * action update
-        *
-        * @param In2code\Femanagerextended\Domain\Model\User $user
-        * @TYPO3\CMS\Extbase\Annotation\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
-        * @TYPO3\CMS\Extbase\Annotation\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
-        */
-       public function updateAction($user): void
-       {
-           parent::updateAction($user);
-       }
-   }
-
-
-NewController.php:
-
-.. code-block:: text
-
-   namespace In2code\Femanagerextended\Controller;
-
-   use In2code\Femanager\Controller\NewController as FemanagerNewController;
-
-   class NewController extends FemanagerNewController
-   {
-
-       /**
-       * action create
-       *
-       * @param In2code\Femanagerextended\Domain\Model\User $user
-       * @TYPO3\CMS\Extbase\Annotation\Validate("In2code\Femanager\Domain\Validator\ServersideValidator", param="user")
-       * @TYPO3\CMS\Extbase\Annotation\Validate("In2code\Femanager\Domain\Validator\PasswordValidator", param="user")
-       */
-       public function createAction($user): void
-       {
-           parent::createAction($user);
-       }
-   }


### PR DESCRIPTION
Relates #367 and #379

I'm not sure, if we still need to override the controllers in TYPO3 10.4, if we just want to extend the domain model. If we use `$extbaseObjectContainer->registerImplementation()` to register the extended model, Extbase should handle this.

Perhaps we need this in the the ext_tables.php to let the rest of TYPO3 know about the extended model:

```
$GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\In2code\Femanager\Domain\Model\User::class] = [
    'className' => \In2code\Femanagerextended\Domain\Model\User::class,
];
```