### PR TITLE
[BUGFIX] Fix email subject for createUserNotify and createAdminNotify

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -250,7 +250,10 @@ abstract class AbstractController extends ActionController
                 $this->settings['new']['email']['createUserNotify']['sender']['email']['value'],
                 $this->settings['new']['email']['createUserNotify']['sender']['name']['value']
             ),
-            $this->settings['new']['email']['createUserNotify']['subject']['data'],
+            $this->contentObject->cObjGetSingle(
+                $this->config['new.']['email.']['createUserNotify.']['subject'],
+                $this->config['new.']['email.']['createUserNotify.']['subject.']
+            ),
             $variables,
             $this->config['new.']['email.']['createUserNotify.']
         );
@@ -265,7 +268,10 @@ abstract class AbstractController extends ActionController
                     $this->settings['new']['email']['createAdminNotify']['receiver']['name']['value']
                 ),
                 StringUtility::makeEmailArray($user->getEmail(), $user->getUsername()),
-                $this->settings['new']['email']['createAdminNotify']['subject']['data'],
+                $this->contentObject->cObjGetSingle(
+                    $this->config['new.']['email.']['createAdminNotify.']['subject'],
+                    $this->config['new.']['email.']['createAdminNotify.']['subject.']
+                ),
                 $variables,
                 $this->config['new.']['email.']['createAdminNotify.']
             );


### PR DESCRIPTION
Got the following problem with createUserNotify and createAdminNotify mails:

`Argument 4 passed to In2code\Femanager\Domain\Service\SendMailService::send() must be of the type string, null given, called in / ... /femanager/Classes/Controller/AbstractController.php on line 255`

Fixed it the same way as this one: https://github.com/in2code-de/femanager/commit/4307693f379cccab3f7d4fec8e4ee463434776b4