### PR TITLE
[FIX] Fixes CleanUserGroup DataProcessor

### DIFF
--- a/Classes/DataProcessor/CleanUserGroup.php
+++ b/Classes/DataProcessor/CleanUserGroup.php
@@ -14,7 +14,7 @@ class CleanUserGroup extends AbstractDataProcessor
      */
     public function process(array $arguments): array
     {
-        if (empty($arguments['user']['usergroup'][0]) && empty($arguments['user']['usergroup'][0]['__identity'])) {
+        if (is_array($arguments['user']['usergroup']) && empty($arguments['user']['usergroup'][0]) && empty($arguments['user']['usergroup'][0]['__identity'])) {
             unset($arguments['user']['usergroup'][0]);
         }
         return $arguments;


### PR DESCRIPTION
If there is no usergroup selected in the registration and the form is submitted it brakes before the validation is executed with the error "Cannot unset string offsets" in Line 18 of femanager/Classes/DataProcessor/CleanUserGroup.php