### PR TITLE
[TASK] Removes configPID from ext_typoscript_setup.typoscript

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -440,7 +440,7 @@ abstract class AbstractController extends ActionController
 
             // Retrieve user TSconfig of currently logged in user
             $userTsConfig = $GLOBALS['BE_USER']->getTSConfig();
-            if (is_array($userTsConfig['tx_femanager.'])) {
+            if (is_array($userTsConfig['tx_femanager.']) && is_array($this->moduleConfig)) {
                 $this->moduleConfig = array_merge_recursive($this->moduleConfig, $userTsConfig['tx_femanager.']);
             }
         }

--- a/Configuration/TypoScript/Main/setup.typoscript
+++ b/Configuration/TypoScript/Main/setup.typoscript
@@ -1774,3 +1774,8 @@ feManagerStateSelection {
     features.requireCHashArgumentForActionArguments = 0
   }
 }
+
+##################################################
+# Configuration Setting for Backend Module
+##################################################
+module.tx_femanager.settings.configPID = 1

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -2194,7 +2194,8 @@ only admins should confirm the requests), **User TSConfig** can be used like (to
 Configuration
 """""""""""""
 
-All settings for the backend module are done in ext_typoscript_setup.txt in the key module.tx_femanager.
+Nearly all settings for the backend module are done in ext_typoscript_setup.txt in the key module.tx_femanager.
+One setting must be done in your TypoScript Template, the setting module.tx_femanager.settings.configPID should be set in your TypoScript, the default is 1.
 
 You can overwrite these settings in your page TS.
 

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -5,9 +5,6 @@ module.tx_femanager {
     partialRootPath = EXT:femanager/Resources/Private/Partials/
     layoutRootPath = EXT:femanager/Resources/Private/Layouts/
   }
-  settings {
-    configPID = 1
-  }
 }
 
 ##################################################


### PR DESCRIPTION
The removed configuration can only be overwritten by another preset file in another extension, it can not be overwritten by PageTS.

