### PR TITLE
Re-fetch session from database to update 'userSession' property of TSFE.

### DIFF
--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -343,6 +343,8 @@ class UserUtility extends AbstractUtility
         $GLOBALS['TSFE']->fe_user->setAndSaveSessionData('dummy', true);
         // create the session (destroys all existing session data in the session backend!)
         $GLOBALS['TSFE']->fe_user->createUserSession(['uid' => (int)$user->getUid()]);
+        // re-fetch the session from the database so that the internal 'userSession' property of TSFE gets updated
+        $GLOBALS['TSFE']->fe_user->fetchUserSession();
         // write the session data again to the session backend; preserves what was there before!!
         $GLOBALS['TSFE']->fe_user->setAndSaveSessionData('dummy', true);
     }


### PR DESCRIPTION
Without this, the session is persisted to the database, but not updated inside TSFE and so the setting of the dummy data wipes out the user id and effectively logs off the user.