### PR TITLE
[BUGFIX] Notification mail to admin shows changes

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -172,7 +172,7 @@ abstract class AbstractController extends ActionController
             $this->sendMailService->send(
                 'updateNotify',
                 StringUtility::makeEmailArray(
-                    ConfigurationUtility::getValue('edit/email/createUserNotify/notifyAdmin/receiver/email/value') ??
+                    ConfigurationUtility::getValue('edit/email/createUserNotify/notifyAdmin/receiver/email/value') ?:
                     ConfigurationUtility::getValue('edit/notifyAdmin'),
                     $this->settings['edit']['email']['notifyAdmin']['receiver']['name']['value'] ?? null
                 ),

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -180,7 +180,7 @@ abstract class AbstractController extends ActionController
                 'Profile update',
                 [
                     'user' => $user,
-                    'changes' => UserUtility::getDirtyPropertiesFromUser($existingUser),
+                    'changes' => UserUtility::getDirtyPropertiesFromUser($user),
                     'settings' => $this->settings,
                 ],
                 $this->config['edit.']['email.']['notifyAdmin.'] ?? []

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -203,7 +203,7 @@ class ConfigurationUtility extends AbstractUtility
         if (self::getValue(
             'edit/notifyAdmin',
             $config
-        ) && self::getValue(
+        ) || self::getValue(
             'edit/email/createUserNotify/notifyAdmin/receiver/email/value',
             $config
         )) {

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -8,13 +8,21 @@ Changelog
    :header-rows: 1
 
 -
+      :Version: 7.1.1
+      :Date: 2023-03-16
+      :Changes:
+
+      * [BUGFIX] Notification email to admin now sends changes again
+      * [BUGFIX] Notification email to admin is also sent when adding recipient's address to flex form only
+
+-
       :Version: 7.1.0
       :Date: 2023-01-19
       :Changes:
 
       * [FEATURE] Add support for PHP 8 and 8.1  - thx to Stefan Busemann, Bastien Lutz, Mathias Bolt Lesniak, Thomas Löffler, Johannes Seipelt
       * [BUGFIX] Re-fetch session from database to update 'userSession' property of TSFE.	Thx to Thomas Off <thomas.off@retiolum.de>
-      * [BUGFIX] Add hash check for inivtation action - thx to Max Schäfer & Dennis Schober-Wenger
+      * [BUGFIX] Add hash check for invitation action - thx to Max Schäfer & Dennis Schober-Wenger
       * [REFACTOR] Remove deprecated code and introduce rector  - thx to Thomas Löffler
 
 -


### PR DESCRIPTION
UserUtility::getDirtyPropertiesFromUser() expects the new, changed user data and compares that against the old user data. So comparing the existing user data against itself caused that changes were never submitted in the `notifyAdmin` email.