### PR TITLE
Backport of Bugfix: admin confirmation mail problems

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -154,7 +154,7 @@ abstract class AbstractController extends ActionController
                 'Profile update',
                 [
                     'user' => $user,
-                    'changes' => UserUtility::getDirtyPropertiesFromUser($existingUser),
+                    'changes' => UserUtility::getDirtyPropertiesFromUser($user),
                     'settings' => $this->settings
                 ],
                 $this->config['edit.']['email.']['notifyAdmin.']

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -147,7 +147,7 @@ abstract class AbstractController extends ActionController
                 'updateNotify',
                 StringUtility::makeEmailArray(
                     $this->settings['edit']['email']['notifyAdmin']['receiver']['email']['value']
-                    ?? $this->settings['edit']['notifyAdmin'],
+                        ?: $this->settings['edit']['notifyAdmin'],
                     $this->settings['edit']['email']['notifyAdmin']['receiver']['name']['value']
                 ),
                 StringUtility::makeEmailArray($user->getEmail(), $user->getUsername()),
@@ -238,7 +238,8 @@ abstract class AbstractController extends ActionController
             $this->sendMailService->send(
                 'createNotify',
                 StringUtility::makeEmailArray(
-                    !empty($this->settings['new']['email']['createAdminNotify']['receiver']['email']['value']) ? $this->settings['new']['email']['createAdminNotify']['receiver']['email']['value'] : $this->settings['new']['notifyAdmin'],
+                    $this->settings['new']['email']['createAdminNotify']['receiver']['email']['value']
+                        ?: $this->settings['new']['notifyAdmin'],
                     $this->settings['new']['email']['createAdminNotify']['receiver']['name']['value']
                 ),
                 StringUtility::makeEmailArray($user->getEmail(), $user->getUsername()),

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -30,7 +30,7 @@ All changes are documented on https://docs.typo3.org/typo3cms/extensions/femanag
       :Date: 2023-01-25
       :Changes:
 
-      * [BUGFIX] Security: Missing Hash Check for inviation controller - Invitation Templates must be updraded (if a custom template is used)
+      * [BUGFIX] Security: Missing Hash Check for invitation controller - Invitation Templates must be updated (if a custom template is used)
 
 -
       :Version: 5.5.2

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -18,6 +18,14 @@ All changes are documented on https://docs.typo3.org/typo3cms/extensions/femanag
       Release Description
 
 -
+      :Version: 5.5.4
+      :Date: 2023-03-16
+      :Changes:
+
+      * [BUGFIX] Notification email to admin now sends changes again
+      * [BUGFIX] Notification email to admin is also sent when adding recipient's address to flex form only
+
+-
       :Version: 5.5.3
       :Date: 2023-01-25
       :Changes:


### PR DESCRIPTION
UserUtility::getDirtyPropertiesFromUser() expects the new, changed user data and compares that against the old user data. So comparing the existing user data against itself caused that changes were never submitted in the `notifyAdmin` email.
Notification email to admin is also sent when adding recipient's address to flex form only
This is a backport to v5.