### PR TITLE
[BUGFIX] Fixed issue with custom upload field

### DIFF
--- a/Classes/DataProcessor/ImageManipulation.php
+++ b/Classes/DataProcessor/ImageManipulation.php
@@ -29,6 +29,9 @@ class ImageManipulation extends AbstractDataProcessor
             if ($this->isFileIdentifierGiven($arguments, $property) || $this->isUploadError($arguments, $property)) {
                 unset($arguments['user'][$property]);
             } else {
+                // Convert property name
+                $property = GeneralUtility::lcfirst(GeneralUtility::underscoredToUpperCamelCase($property));
+
                 // file upload given
                 foreach ($arguments['user'][$property] ?? [] as $fileItem) {
                     /** @noinspection PhpMethodParametersCountMismatchInspection */


### PR DESCRIPTION
Updated property name to camelcase for domain model field.

For example: If you have custom field with domain modeling format such as `tx_example_domain_model_documents` it won't work and throw error. this will convert field name in camel case and it will work!
