### PR TITLE
BUGFIX: missing email AdminNotify after editing of user profile

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -172,8 +172,8 @@ abstract class AbstractController extends ActionController
             $this->sendMailService->send(
                 'updateNotify',
                 StringUtility::makeEmailArray(
-                    ConfigurationUtility::getValue('edit/email/createUserNotify/notifyAdmin/receiver/email/value') ?:
-                    ConfigurationUtility::getValue('edit/notifyAdmin'),
+                    ConfigurationUtility::getValue('edit/email/notifyAdmin/receiver/email/value', $this->settings) ?:
+                    ConfigurationUtility::getValue('edit/notifyAdmin', $this->settings),
                     $this->settings['edit']['email']['notifyAdmin']['receiver']['name']['value'] ?? null
                 ),
                 StringUtility::makeEmailArray($user->getEmail(), $user->getUsername()),

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -24,8 +24,8 @@ class ConfigurationUtility extends AbstractUtility
         'edit./requestRedirect' => 'TEXT',
         'edit./requestRedirect.' => [],
         'edit/fillEmailWithUsername' => '0',
-        'edit/notifyAdmin' => '0',
-        'edit/email/createUserNotify/notifyAdmin/receiver/email/value' => '',
+        'edit/notifyAdmin' => '',
+        'edit/email/notifyAdmin/receiver/email/value' => '',
         'edit/misc/passwordSave' => '',
         'invitation/misc/passwordSave' => '',
         'invitation./email./invitationAdminNotify.' => [],
@@ -198,17 +198,12 @@ class ConfigurationUtility extends AbstractUtility
         }
     }
 
-    public static function notifyAdminAboutEdits($config)
+    public static function notifyAdminAboutEdits($settings)
     {
-        if (self::getValue(
-            'edit/notifyAdmin',
-            $config
-        ) || self::getValue(
-            'edit/email/createUserNotify/notifyAdmin/receiver/email/value',
-            $config
-        )) {
-            return true;
-        }
-        return false;
+        return self::getValue('edit/email/notifyAdmin/_enable.value', $settings)
+            && (
+                self::getValue('edit/email/notifyAdmin/receiver/email/value', $settings)
+                || self::getValue('edit/notifyAdmin', $settings)
+            );
     }
 }

--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -200,7 +200,7 @@ class ConfigurationUtility extends AbstractUtility
 
     public static function notifyAdminAboutEdits($settings)
     {
-        return self::getValue('edit/email/notifyAdmin/_enable.value', $settings)
+        return self::getValue('edit/email/notifyAdmin/_enable/value', $settings)
             && (
                 self::getValue('edit/email/notifyAdmin/receiver/email/value', $settings)
                 || self::getValue('edit/notifyAdmin', $settings)

--- a/Configuration/TypoScript/Main/setup.typoscript
+++ b/Configuration/TypoScript/Main/setup.typoscript
@@ -946,7 +946,7 @@ plugin.tx_femanager {
           #          }
         }
 
-        # Email sent to admin when user updates his/her profile and (if configured) request was confirmed by admin.
+        # Email sent when user updates his/her profile and (if configured) request was confirmed by admin.
         notifyAdmin {
           ##########################
           # Set values (overwrite)

--- a/Configuration/TypoScript/Main/setup.typoscript
+++ b/Configuration/TypoScript/Main/setup.typoscript
@@ -946,7 +946,7 @@ plugin.tx_femanager {
           #          }
         }
 
-        # Email for if update request was refused by admin
+        # Email sent to admin when user updates his/her profile and (if configured) request was confirmed by admin.
         notifyAdmin {
           ##########################
           # Set values (overwrite)


### PR DESCRIPTION
Corrected config paths, added second parameter to getValue() method calls and added the check if admin notificatin is enabled in general to notifyAdminAboutEdits().