### PR TITLE
[BUGFIX] Prevent undefined array key for empty configPID

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -451,7 +451,7 @@ abstract class AbstractController extends ActionController
         $this->config = $this->config[BackendUtility::getPluginOrModuleString() . '.']['tx_femanager.']['settings.'] ?? [];
 
         if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isBackend()) {
-            $config = BackendUtility::loadTS($this->allConfig['settings']['configPID']);
+            $config = BackendUtility::loadTS($this->allConfig['settings']['configPID'] ?? null);
             if (is_array($config['plugin.']['tx_femanager.']['settings.'] ?? null)) {
                 $this->config = $config['plugin.']['tx_femanager.']['settings.'];
                 $this->settings = $this->config;


### PR DESCRIPTION
In case the module is used outside of a page with a TypoScript template, there is no `configPID` defined. In this case, the template of the current page will be used.

Relates: #442
Resolves: #502