### PR TITLE
[BUGFIX] Add full object support in getDirtyPropertiesFromUser()

### DIFF
--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -259,9 +259,16 @@ class UserUtility extends AbstractUtility
                             $dirtyProperties[$propertyName]['old'] = $oldPropertyValue->getTimestamp();
                             $dirtyProperties[$propertyName]['new'] = $newPropertyValue->getTimestamp();
                         }
-                    } else {
+                    } elseif(get_class($oldPropertyValue) === ObjectStorage::class) {
                         $titlesOld = ObjectUtility::implodeObjectStorageOnProperty($oldPropertyValue);
                         $titlesNew = ObjectUtility::implodeObjectStorageOnProperty($newPropertyValue);
+                        if ($titlesOld !== $titlesNew) {
+                            $dirtyProperties[$propertyName]['old'] = $titlesOld;
+                            $dirtyProperties[$propertyName]['new'] = $titlesNew;
+                        }
+                    } else {
+                        $titlesOld = ObjectAccess::getProperty($oldPropertyValue, 'uid');
+                        $titlesNew = ObjectAccess::getProperty($newPropertyValue, 'uid');
                         if ($titlesOld !== $titlesNew) {
                             $dirtyProperties[$propertyName]['old'] = $titlesOld;
                             $dirtyProperties[$propertyName]['new'] = $titlesNew;

--- a/Classes/Utility/UserUtility.php
+++ b/Classes/Utility/UserUtility.php
@@ -267,11 +267,11 @@ class UserUtility extends AbstractUtility
                             $dirtyProperties[$propertyName]['new'] = $titlesNew;
                         }
                     } else {
-                        $titlesOld = ObjectAccess::getProperty($oldPropertyValue, 'uid');
-                        $titlesNew = ObjectAccess::getProperty($newPropertyValue, 'uid');
-                        if ($titlesOld !== $titlesNew) {
-                            $dirtyProperties[$propertyName]['old'] = $titlesOld;
-                            $dirtyProperties[$propertyName]['new'] = $titlesNew;
+                        $uidOld = ObjectAccess::getProperty($oldPropertyValue, 'uid');
+                        $uidNew = ObjectAccess::getProperty($newPropertyValue, 'uid');
+                        if ($uidOld !== $uidNew) {
+                            $dirtyProperties[$propertyName]['old'] = $uidOld;
+                            $dirtyProperties[$propertyName]['new'] = $uidNew;
                         }
                     }
                 }


### PR DESCRIPTION
This change ensures, that `ObjectUtility::implodeObjectStorageOnProperty()` is only used, when the evaluated object is of type `ObjectStorage`. For all other objects, the `uid` values are compared.

Refs #505