### PR TITLE
[BUGFIX] Restore email notification to admin after registration

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -285,7 +285,7 @@ abstract class AbstractController extends ActionController
             $this->config
         );
         if (!$createAdminNotify) {
-            $createAdminNotify = ConfigurationUtility::getValue('new./notifyAdmin', $this->config);
+            $createAdminNotify = $this->settings['new']['notifyAdmin'];
         }
 
         // send notify email to admin


### PR DESCRIPTION
Its a working solution to restore the flexform email notification to admin after registration.
resolve #472, see https://github.com/in2code-de/femanager/issues/472#issuecomment-1476492996