### PR TITLE
[BUGFIX] Pass proper argument to form error partial

### DIFF
--- a/Resources/Private/Templates/Edit/ConfirmUpdateRequest.html
+++ b/Resources/Private/Templates/Edit/ConfirmUpdateRequest.html
@@ -7,6 +7,6 @@
 
 	<f:section name="main">
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-		<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+		<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 	</f:section>
 </div>

--- a/Resources/Private/Templates/Edit/Edit.html
+++ b/Resources/Private/Templates/Edit/Edit.html
@@ -9,7 +9,7 @@
 
 	<f:section name="main">
 		<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-		<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+		<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 
 		<div class="femanager_edit">
 			<f:if condition="{user}">

--- a/Resources/Private/Templates/Invitation/Edit.html
+++ b/Resources/Private/Templates/Invitation/Edit.html
@@ -8,7 +8,7 @@ Available variables:
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}"/>
-	<f:render partial="Misc/FormErrors" arguments="{object:User}"/>
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}"/>
 
 	<div class="femanager_invitation_edit">
 		<f:if condition="{user}">

--- a/Resources/Private/Templates/Invitation/New.html
+++ b/Resources/Private/Templates/Invitation/New.html
@@ -11,7 +11,7 @@ Invitation / New
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-	<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 
 	<div class="femanager_invitation_new">
 		<f:form

--- a/Resources/Private/Templates/New/New.html
+++ b/Resources/Private/Templates/New/New.html
@@ -8,7 +8,7 @@
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}" />
-	<f:render partial="Misc/FormErrors" arguments="{object:User}" />
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}" />
 	<f:render partial="Misc/ResendConfirmation" arguments="{_all}" />
 	<div class="femanager_new">
 		<f:form

--- a/Resources/Private/Templates/New/ResendConfirmationDialogue.html
+++ b/Resources/Private/Templates/New/ResendConfirmationDialogue.html
@@ -4,7 +4,7 @@ User / Status
 
 <f:section name="main">
 	<f:render partial="Misc/FlashMessages" arguments="{_all}"/>
-	<f:render partial="Misc/FormErrors" arguments="{object:User}"/>
+	<f:render partial="Misc/FormErrors" arguments="{object: 'user'}"/>
 	<div class="femanager_new">
 		<h3>
 			<f:translate key="resendConfirmationMailTitle">Resend confirmation mail</f:translate>


### PR DESCRIPTION
Successor to #304 containing only the fix of passing the proper parameter to the form error partial.