### PR TITLE
[BUGFIX] Replace incorrect response in AdminConfirmation

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -33,7 +33,6 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
-use TYPO3\CMS\Extbase\Http\ForwardResponse;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;

--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -25,6 +25,7 @@ use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Backend\Utility\BackendUtility as BackendUtilityCore;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\UploadedFile;
 use TYPO3\CMS\Core\Resource\DuplicationBehavior;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
@@ -387,7 +388,7 @@ abstract class AbstractController extends ActionController
                 ($status ? $status . 'Redirect' : 'redirect'),
                 $redirectByActionName
             );
-            if ($redirectTarget instanceof ForwardResponse) {
+            if ($redirectTarget instanceof RedirectResponse) {
                 $this->addFlashMessage(LocalizationUtility::translate('create'));
             }
             return $redirectTarget;


### PR DESCRIPTION
The finalCreate() method checked for a ForwardResponse to send a FlashMessage at the end. There is a RedirectResponse given, so there was never a FlashMessage send