### PR TITLE
[BUGFIX] Open the "terms & conditions" page in a new tab

### DIFF
--- a/Resources/Private/Partials/Fields/Terms.html
+++ b/Resources/Private/Partials/Fields/Terms.html
@@ -15,7 +15,7 @@
                 </f:if>
                 <f:if condition="{settings.misc.termsUrl}">
                     <f:then>
-                        (<f:link.page pageUid="{settings.misc.termsUrl}"><f:translate key="tx_femanager_domain_model_user.termslinktext" /></f:link.page>)
+                        (<f:link.page pageUid="{settings.misc.termsUrl}" target="_blank"><f:translate key="tx_femanager_domain_model_user.termslinktext" /></f:link.page>)
                     </f:then>
                 </f:if>
             </label>


### PR DESCRIPTION
This way, the user will not lose the data in the form.

Releases: main, v7