### PR TITLE
[BUGFIX] Fix a typo in the labels

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -52,7 +52,7 @@
 				<source>Female</source>
 			</trans-unit>
 			<trans-unit id="tx_femanager_domain_model_user.gender.item2">
-				<source>Divers</source>
+				<source>Diverse</source>
 			</trans-unit>
 			<trans-unit id="tx_femanager_domain_model_user.address">
 				<source>Address</source>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -40,7 +40,7 @@
 				<source>female</source>
 			</trans-unit>
 			<trans-unit id="tx_femanager_domain_model_user.gender.item2">
-				<source>divers</source>
+				<source>diverse</source>
 			</trans-unit>
 			<trans-unit id="tx_femanager_domain_model_user.address">
 				<source>Address</source>


### PR DESCRIPTION
The English spelling for "diverse" (the gender) is "diverse", not "divers".

Releases: main, v7