### PR TITLE
[BUGFIX] Allow the PHPStan extension installer for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -95,8 +95,9 @@
     "bin-dir": ".Build/bin",
     "sort-packages": true,
     "allow-plugins": {
-      "typo3/cms-composer-installers": true,
-      "typo3/class-alias-loader": true
+      "phpstan/extension-installer": true,
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true
     }
   },
   "scripts": {


### PR DESCRIPTION
This fixes an interactive question when running `composer install` or `composer update` with Composer V2.7.

Also sort the allowed Composer plugins for better maintainability.

Releases: main, v7