### PR TITLE
[BUGFIX] Fix the Rector PHP target version

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,7 +22,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     // Define your target version which you want to support
-    $rectorConfig->phpVersion(PhpVersion::PHP_81);
+    $rectorConfig->phpVersion(PhpVersion::PHP_74);
 
     // If you only want to process one/some TYPO3 extension(s), you can specify its path(s) here.
     // If you use the option --config change __DIR__ to getcwd()


### PR DESCRIPTION
The V7 branch of this extension still needs to support PHP 7.4 (to fully support TYPO3 11LTS). So the Rector PHP target version needs to be 7.4., not 8.1.

Releases: v7