### PR TITLE
[BUGFIX] Fix composer script calls in the `test:rector:fix` script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,8 +112,8 @@
     "test:ts:lint": "typoscript-lint -c .project/tests/typoscript-lint.yml --fail-on-warnings",
     "test:rector": "rector -n",
     "test:rector:fix": [
-      "rector",
-      "test:php:fix"
+      "@test:rector",
+      "@test:php:fix"
     ],
     "prepare-release": [
       "@extension-create-libs",


### PR DESCRIPTION
When Composer scripts call other Composer scripts, the called script needs to be prefixed with `@`.

Also call the existing Rector script for consistency instead of calling Rector directly.

Releases: main, v7