### PR TITLE
[TASK] Update Symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-json": "*",
     "ext-pdo": "*",
     "typo3/cms-core": "^12.3.0",
-    "symfony/config": "^6.1"
+    "symfony/config": "^6.3 || ^7.0"
   },
   "repositories": [
     {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-json": "*",
     "ext-pdo": "*",
     "typo3/cms-core": "^12.3.0",
-    "symfony/config": "^6.3 || ^7.0"
+    "symfony/config": "^6.4 || ^7.0"
   },
   "repositories": [
     {


### PR DESCRIPTION
Since TYPO3 12.4.10 the core allows Symfony 7 in its dependencies (`"symfony/config:^6.4 || ^7.0"`)

@see https://forge.typo3.org/issues/102746

Related: #552