### PR TITLE
Add header row to Features/Events/Index.rst

### DIFF
--- a/Documentation/Features/Events/Index.rst
+++ b/Documentation/Features/Events/Index.rst
@@ -26,6 +26,17 @@ Events List
    :header-rows: 1
 
    -  :Event:
+         Event
+      :Where:
+         Where
+      :Replaces signal:
+         Replaces signal
+      :Parameters:
+         Parameters
+      :Description:
+         Description
+
+   -  :Event:
          AdminConfirmationUserEvent
       :Where:
          UserBackendController->confirmUserAction()


### PR DESCRIPTION
Archiving better readability by adding a real header.

Currently the first row of data does show up as the table header.

See image:
![image](https://github.com/user-attachments/assets/50926e6d-b475-4648-b88d-deabdcb6d286)
