### PR TITLE
[BUGFIX] Avoid deprecated PHP function `utf8_decode`

### DIFF
--- a/Classes/Domain/Validator/CaptchaValidator.php
+++ b/Classes/Domain/Validator/CaptchaValidator.php
@@ -41,7 +41,7 @@ class CaptchaValidator extends AbstractValidator
         $wordHash = $wordObject->getWordHash();
         if (!empty($wordHash) && !empty($this->pluginVariables['captcha'])) {
             if ($wordObject->getHashFunction() == 'md5') {
-                if (md5(strtolower(utf8_decode($this->pluginVariables['captcha']))) == $wordHash) {
+                if (md5(strtolower(mb_convert_encoding((string)$this->pluginVariables['captcha'], 'ISO-8859-1'))) == $wordHash) {
                     $wordRepository->cleanUpWord();
                     $isValid = true;
                 }

--- a/Classes/Domain/Validator/ClientsideValidator.php
+++ b/Classes/Domain/Validator/ClientsideValidator.php
@@ -220,7 +220,7 @@ class ClientsideValidator extends AbstractValidator
                         );
                         $wordObject = $wordRepository->getWord();
                         $wordHash = $wordObject->getWordHash();
-                        $userVal = md5(strtolower(utf8_decode($this->getValue())));
+                        $userVal = md5(strtolower(mb_convert_encoding($this->getValue(), 'ISO-8859-1')));
                         if ($wordHash !== $userVal) {
                             $this->addMessage('validationErrorCaptcha', 'captcha');
                             $this->isValid = false;


### PR DESCRIPTION
`utf8_decode` has been deprecated, and calling it in PHP >= 8.2 throws a deprecation warning.

This change bringt the two affected calls in line with what we already have in `main` in this commit:
134418314d6db55d463bd0aa882942ba10710c1b

https://www.php.net/manual/en/function.utf8-decode.php