### PR TITLE
Remove side-effect in User crdate getter

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -469,7 +469,7 @@ abstract class AbstractController extends ActionController
     protected function isSpoof(User $user, int $uid, string $receivedToken): bool
     {
         $errorOnProfileUpdate = false;
-        $knownToken = GeneralUtility::hmac((string)$user->getUid(), (string)$user->getCrdate()->getTimestamp());
+        $knownToken = GeneralUtility::hmac((string)$user->getUid(), (string)($user->getCrdate() ?: new \DateTime('01.01.1970'))->getTimestamp());
 
         //check if the params are valid
         if (!is_string($receivedToken) || !hash_equals($knownToken, $receivedToken)) {

--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -39,7 +39,7 @@ class EditController extends AbstractFrontendController
         if ($this->user) {
             $token = GeneralUtility::hmac(
                 (string)$this->user->getUid(),
-                (string)$this->user->getCrdate()->getTimestamp()
+                (string)($this->user->getCrdate() ?: new \DateTime('01.01.1970'))->getTimestamp()
             );
         }
         $this->view->assignMultiple([

--- a/Classes/Domain/Model/User.php
+++ b/Classes/Domain/Model/User.php
@@ -565,10 +565,6 @@ class User extends AbstractEntity
      */
     public function getCrdate()
     {
-        if ($this->crdate === null) {
-            // timestamp is zero
-            $this->crdate = new DateTime('01.01.1970');
-        }
         return $this->crdate;
     }
 


### PR DESCRIPTION
In the rare case that crdate is null for a user, this now picks the 0 DateTime as an option right in the spots where the token is created instead of inside the User model

Closes #430 