### PR TITLE
Clean up RemovePasswordIfEmptyMiddleware

### DIFF
--- a/Classes/Middleware/RemovePasswordIfEmptyMiddleware.php
+++ b/Classes/Middleware/RemovePasswordIfEmptyMiddleware.php
@@ -16,20 +16,22 @@ class RemovePasswordIfEmptyMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
-        $typoscript = $configurationManager->getConfiguration(
-            ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT,
-            'femanager'
-        );
         $requestBody = $request->getParsedBody();
 
-        if (!empty($typoscript['plugin.']['tx_femanager.']['settings.']['edit.']['misc.']['keepPasswordIfEmpty']) &&
-            empty($requestBody['tx_femanager_edit']['user']['password']) &&
-            empty($requestBody['tx_femanager_edit']['password_repeat'])) {
-            $requestBody = $request->getParsedBody();
-            unset($requestBody['tx_femanager_edit']['user']['password']);
-            unset($requestBody['tx_femanager_edit']['password_repeat']);
-            $request = $request->withParsedBody($requestBody);
+        if (isset($requestBody['tx_femanager_edit'])) {
+            $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+            $typoscript = $configurationManager->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT,
+                'femanager'
+            );
+
+            if (!empty($typoscript['plugin.']['tx_femanager.']['settings.']['edit.']['misc.']['keepPasswordIfEmpty']) &&
+                empty($requestBody['tx_femanager_edit']['user']['password']) &&
+                empty($requestBody['tx_femanager_edit']['password_repeat'])) {
+                unset($requestBody['tx_femanager_edit']['user']['password']);
+                unset($requestBody['tx_femanager_edit']['password_repeat']);
+                $request = $request->withParsedBody($requestBody);
+            }
         }
 
         return $handler->handle($request);


### PR DESCRIPTION
Fixes in2code-pro/femanager#36 

* Skips the entire logic if we're not on a `tx_femanager_edit` action
* Removes the second fetch of the request body from the request object, reutilizing the initally acquired request body for the outside conditional check