### PR TITLE
[BUGFIX] Pass request object to mail service in controller context

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -180,7 +180,8 @@ class EditController extends AbstractFrontendController
                 'user' => $user,
                 'settings' => $this->settings,
             ],
-            $this->config['edit.']['email.']['updateRequestRefused.']
+            $this->config['edit.']['email.']['updateRequestRefused.'],
+            $this->request
         );
         $this->logUtility->log(Log::STATUS_PROFILEUPDATEREFUSEDADMIN, $user);
         $this->addFlashMessage(LocalizationUtility::translateByState(Log::STATUS_PROFILEUPDATEREFUSEDADMIN));

--- a/Classes/Controller/InvitationController.php
+++ b/Classes/Controller/InvitationController.php
@@ -138,7 +138,8 @@ class InvitationController extends AbstractFrontendController
                     'user' => $user,
                     'settings' => $this->settings,
                 ],
-                ConfigurationUtility::getValue('invitation./email./invitationAdminNotifyStep1.', $this->config)
+                ConfigurationUtility::getValue('invitation./email./invitationAdminNotifyStep1.', $this->config),
+                $this->request
             );
         }
 
@@ -225,7 +226,8 @@ class InvitationController extends AbstractFrontendController
                     'user' => $user,
                     'settings' => $this->settings,
                 ],
-                ConfigurationUtility::getValue('invitation./email./invitationAdminNotify.', $this->config)
+                ConfigurationUtility::getValue('invitation./email./invitationAdminNotify.', $this->config),
+                $this->request
             );
         }
         $user = UserUtility::overrideUserGroup($user, $this->settings, 'invitation');
@@ -270,7 +272,8 @@ class InvitationController extends AbstractFrontendController
                         'user' => $user,
                         'settings' => $this->settings,
                     ],
-                    $this->config['invitation.']['email.']['invitationRefused.']
+                    $this->config['invitation.']['email.']['invitationRefused.'],
+                    $this->request
                 );
             }
 


### PR DESCRIPTION
f:translate requires the request object to resolve the extension name for localization strings, so pass them to the mail service whenever it's available