### PR TITLE
sr_freecap integration fixes

### DIFF
--- a/Classes/Controller/EditController.php
+++ b/Classes/Controller/EditController.php
@@ -54,6 +54,8 @@ class EditController extends AbstractFrontendController
     #[Validate(['validator' => CaptchaValidator::class, 'param' => 'captcha'])]
     public function updateAction(User $user, ?string $captcha = null)
     {
+        $this->validateMissingCaptcha('edit');
+
         $currentUser = UserUtility::getCurrentUser();
         $userValues = $this->request->getArgument('user') ?? [];
         $token = $this->request->getArgument('token') ?? null;

--- a/Classes/Controller/InvitationController.php
+++ b/Classes/Controller/InvitationController.php
@@ -59,6 +59,8 @@ class InvitationController extends AbstractFrontendController
     #[Validate(['validator' => CaptchaValidator::class, 'param' => 'captcha'])]
     public function createAction(User $user, ?string $captcha = null): ResponseInterface
     {
+        $this->validateMissingCaptcha('new');
+
         if ($this->ratelimiterService->isLimited()) {
             $this->addFlashMessage(
                 LocalizationUtility::translate('ratelimiter_too_many_attempts'),

--- a/Classes/Controller/NewController.php
+++ b/Classes/Controller/NewController.php
@@ -66,6 +66,8 @@ class NewController extends AbstractFrontendController
     #[Validate(['validator' => CaptchaValidator::class, 'param' => 'captcha'])]
     public function createAction(User $user, ?string $captcha = null): ResponseInterface
     {
+        $this->validateMissingCaptcha('new');
+
         if ($this->ratelimiterService->isLimited()) {
             $this->addFlashMessage(
                 LocalizationUtility::translate('ratelimiter_too_many_attempts'),

--- a/Classes/Domain/Validator/ClientsideValidator.php
+++ b/Classes/Domain/Validator/ClientsideValidator.php
@@ -272,6 +272,7 @@ class ClientsideValidator extends AbstractValidator
                         $wordRepository = GeneralUtility::makeInstance(
                             WordRepository::class
                         );
+                        $wordRepository->setRequest($this->request ?? $GLOBALS["TYPO3_REQUEST"]);
                         $wordObject = $wordRepository->getWord();
                         $wordHash = $wordObject->getWordHash();
                         $userVal = md5(strtolower(mb_convert_encoding($this->getValue(), 'ISO-8859-1')));


### PR DESCRIPTION
This PR includes 2 fixes for the `sr_freecap` captcha integration:

1. `sr_freecap`'s `WordRepository` needs a valid Request to work with. This works fine in serverside validation, but in AJAX/client-side validation the initialized repository doesn't have a Request at hand and thus crashes form submissions with a HTTP 500 error. We simply pass an available request or `$GLOBALS['TYPO3_REQUEST']` instead.

2. If you have `sr_freecap` installed and in server-side validation mode, you could leave the Captcha field empty and forms would still submit fine.

## Details for 2.:

The `CaptchaValidator` is skipped when the `captcha` parameter is empty. This causes forms to pass when you just leave the Captcha input untouched.

This PR adds a `validateMissingCaptcha` method to `AbstractController` which checks for the presence of the `captcha` argument in form submissions, coupled with the extension actually being installed and the fitting TypoScript config being enabled.

If all of that matches and the captcha argument is explicitly '' (empty string) we show the "Wrong captcha code" flash message and redirect back to the originating action.

## "Mitigation"

This feature can be fixed without this patch with setting a `required = 1` validation on the `captcha` field in TypoScript. While this works, just configuring the Captcha validation should make it _required_ anyway, so fixing the underlying issue was done regardless.